### PR TITLE
Fallback AP in secrets e "zone" sempre in inglese

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ Finally, create a `secrets.yaml` file with the following contents:
 ```yaml
 wifi_ssid: "<your-wifi-ssid>"
 wifi_password: "<your-wifi-password>"
+hotspot_wifi_ssid: "<fallback-hotspot-wifi-ssid>"
+hotspot_wifi_password: "<fallback-hotspot-wifi-password>"
 ota_password: "<your-ota-password>"
 api_encryption_key: "<your-encryption-key>"
 ```
 
 * Populate `wifi_ssid` and `wifi_password` with details on how to connect to your network.
+* Choose and write a `hotspot_wifi_ssid` and `hotspot_wifi_password` so the board can create a fallback hotspot in case of a failure of the main wifi network.
 * Write a random password in `ota_password`, which will be used to update the board remotely.
 * Generate an encryption key from [ESPHome](https://esphome.io/components/api.html) and set it in `api_encryption_key`
 

--- a/espkyogate_configuration.yaml
+++ b/espkyogate_configuration.yaml
@@ -13,8 +13,8 @@ wifi:
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "Esp32 Test Fallback Hotspot"
-    password: "12345678"
+    ssid: !secret hotspot_wifi_ssid
+    password: !secret hotspot_wifi_password
 
 captive_portal:
 
@@ -154,7 +154,7 @@ binary_sensor:
       - id: sabotaggio_chiave_falsa
         name: "Sabotaggio Chiave Falsa"
 
-      - id: zona_1
+      - id: zone_1
         name: "Sensore DT Taverna"
         device_class: "motion"
       - id: zone_2
@@ -167,13 +167,13 @@ binary_sensor:
         name: "Scuretto Finestra Lavanderia"
         device_class: "window"
 
-      - id: zona_1_sabotaggio
+      - id: zone_1_sabotaggio
         name: "Sabot. Sensore DT Taverna"
-      - id: zona_2_sabotaggio
+      - id: zone_2_sabotaggio
         name: "Sabot. Finestra Taverna"
-      - id: zona_3_sabotaggio
+      - id: zone_3_sabotaggio
         name: "Sabot. Sensore DT Garage"
-      - id: zona_4_sabotaggio
+      - id: zone_4_sabotaggio
         name: "Sabot. Scuretto Finestra Lavanderia"
 
       - id: excluded_zone_1


### PR DESCRIPTION
Ho modificato leggermente il file YAML in modo da portare in secrets anche la configurazione del AP di fallback e adeguato il README di conseguenza.

Ho sistemato espkyogate_configuration.yaml. Nella seconda parte le zone erano rimaste un po' in italiano, un po' in inglese. Ora sono tutte in inglese.