### PR TITLE
Increase ESP8266 CPU frequency to 160 MHz

### DIFF
--- a/espkyogate_configuration.yaml
+++ b/espkyogate_configuration.yaml
@@ -16,6 +16,8 @@ esphome:
   comment: Alarm System Serial to HA controller  
   includes:
     - components/bentel-kyo/bentel_kyo32.h
+  platformio_options:
+    board_build.f_cpu: 160000000L
 
 uart:
   id: uart_bus


### PR DESCRIPTION
Increasing the CPU frequency from 80 to 160 MHz is increasing the stability for the d1_mini