### PR TITLE
Add event log decoding, output parsing fix, panel mode and status flags

### DIFF
--- a/.github/workflows/esphome-validate.yml
+++ b/.github/workflows/esphome-validate.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Validate invalid output_number test
         run: |
           if esphome config tests/test_invalid_output_number.yaml; then
-            echo "Expected config validation to fail for output_number > 8"
+            echo "Expected config validation to fail for output_number > 16"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -426,12 +426,41 @@ button:
 |------|-------------|
 | `reread_config` | Re-read zone configuration, names, serial numbers from panel |
 | `reset_alarms` | Reset alarm memory on the panel |
-| `read_event_log` | Read panel event log (256 entries) and dump to ESPHome logs |
+| `read_event_log` | Read panel event log (256 entries) with decoded event names and dump to ESPHome logs |
 | `arm_all_away` | Arm all registered partitions in Away mode |
 | `arm_all_home` | Arm all registered partitions in Home/Stay mode |
 | `arm_all_night` | Arm all registered partitions in Night mode |
 | `disarm_all` | Disarm all registered partitions |
 | `arm_preset` | Arm/disarm specific partitions with per-partition mode selection |
+
+### Event Log
+
+The `read_event_log` button reads the panel's circular event log (256 slots of 7 bytes each) and outputs decoded entries to the ESPHome log. Each entry includes a timestamp and a human-readable event description.
+
+Decoded event types:
+
+| Event | Entity |
+|-------|--------|
+| Alarm Partition | Partition 1-8 |
+| Alarm Zone | Zone 1-32 |
+| Recognized Code | Code 1-24 |
+| Arm Partition | Partition 1-8 |
+| Disarm Partition | Partition 1-8 |
+| Special Arming Partition | Partition 1-8 |
+| Special Disarming Partition | Partition 1-8 |
+| Reset Memory Partition | Partition 1-8 |
+| Restore Zone | Zone 1-32 |
+| Remote Command | — |
+
+Example log output:
+```
+Event [246]: 01-03-2026 11:35  Recognized Code n.23
+Event [247]: 01-03-2026 11:35  Arm Partition n.1
+Event [248]: 01-03-2026 11:35  Arm Partition n.2
+Event [250]: 01-03-2026 11:35  Alarm Zone n.5
+Event [252]: 01-03-2026 11:36  Recognized Code n.2
+Event [253]: 01-03-2026 11:36  Disarm Partition n.1
+```
 
 ### Arm Preset Buttons
 

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -76,6 +76,8 @@ enum BinarySensorType : uint8_t {
   SIREN,
   COMMUNICATION,
   OUTPUT_STATE,
+  PANEL_PROGRAMMING_MODE,
+  TROUBLE_ACTIVE,
 };
 
 enum TextSensorType : uint8_t {
@@ -91,6 +93,8 @@ enum TextSensorType : uint8_t {
   TEXT_PARTITION_SIREN_TIMER,
   TEXT_PARTITION_NAME,
   TEXT_CODE_NAME,
+  TEXT_PANEL_MODE_RAW,
+  TEXT_STATUS_FLAGS_RAW,
 };
 
 struct RegisteredTextSensor {
@@ -181,6 +185,8 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   void read_code_names_();
   bool read_event_log_next_();  // reads one 64-byte chunk per call, returns true when done
   static const char *decode_event_code_(uint16_t code, uint8_t *entity_out, char *buf, size_t buf_len);
+  void read_panel_mode_();
+  void read_status_flags_();
   void publish_text_sensors_();
 
   // Checksum helpers
@@ -260,6 +266,15 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   bool partition_disarmed_[KYO_MAX_PARTITIONS]{};
   bool siren_active_{false};
   bool output_state_[KYO_MAX_OUTPUTS]{};
+
+  // Panel Mode register (0x01E6, 2 bytes) — capture-validated idle baseline
+  uint8_t panel_mode_raw_[2]{0x11, 0x10};
+  bool panel_programming_mode_{false};
+
+  // Status Flags register (0x1503, 5 bytes) — capture-validated no-trouble baseline
+  uint8_t status_flags_raw_[5]{0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  bool trouble_active_{false};
+
   bool zone_bypass_[KYO_MAX_ZONES]{};
   bool zone_alarm_memory_[KYO_MAX_ZONES]{};
   bool zone_tamper_memory_[KYO_MAX_ZONES]{};

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -180,6 +180,7 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   void read_partition_names_();
   void read_code_names_();
   bool read_event_log_next_();  // reads one 64-byte chunk per call, returns true when done
+  static const char *decode_event_code_(uint16_t code, uint8_t *entity_out, char *buf, size_t buf_len);
   void publish_text_sensors_();
 
   // Checksum helpers

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -184,7 +184,7 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   void read_partition_names_();
   void read_code_names_();
   bool read_event_log_next_();  // reads one 64-byte chunk per call, returns true when done
-  static const char *decode_event_code_(uint16_t code, uint8_t *entity_out, char *buf, size_t buf_len);
+  const char *decode_event_code_(uint16_t code, uint8_t *entity_out, char *buf, size_t buf_len);
   void read_panel_mode_();
   void read_status_flags_();
   void publish_text_sensors_();

--- a/components/bentel_kyo/binary_sensor.py
+++ b/components/bentel_kyo/binary_sensor.py
@@ -184,7 +184,7 @@ OUTPUT_STATE_SENSOR_SCHEMA = binary_sensor.binary_sensor_schema(
     icon="mdi:electric-switch",
 ).extend(
     {
-        cv.Required(CONF_OUTPUT_NUMBER): cv.int_range(min=1, max=8),
+        cv.Required(CONF_OUTPUT_NUMBER): cv.int_range(min=1, max=16),
         cv.Optional(CONF_OUTPUT_PANEL_NAME): text_sensor.text_sensor_schema(
             icon="mdi:form-textbox",
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/bentel_kyo/binary_sensor.py
+++ b/components/bentel_kyo/binary_sensor.py
@@ -37,6 +37,8 @@ CONF_PARTITION_ALARM = "partition_alarm"
 CONF_PARTITION = "partition"
 CONF_OUTPUT_STATE = "output_state"
 CONF_OUTPUT_NUMBER = "output_number"
+CONF_PANEL_PROGRAMMING_MODE = "panel_programming_mode"
+CONF_TROUBLE_ACTIVE = "trouble_active"
 
 # Zone diagnostic text sensor keys (nested inside zone entries)
 CONF_ZONE_TYPE = "zone_type"
@@ -89,6 +91,8 @@ SENSOR_TYPES = {
     "SIREN": BinarySensorType.SIREN,
     "COMMUNICATION": BinarySensorType.COMMUNICATION,
     "OUTPUT_STATE": BinarySensorType.OUTPUT_STATE,
+    "PANEL_PROGRAMMING_MODE": BinarySensorType.PANEL_PROGRAMMING_MODE,
+    "TROUBLE_ACTIVE": BinarySensorType.TROUBLE_ACTIVE,
 }
 
 TextSensorType = bentel_kyo_ns.enum("TextSensorType")
@@ -283,6 +287,20 @@ SIREN_SCHEMA = binary_sensor.binary_sensor_schema(
     icon="mdi:bullhorn",
 )
 
+# Panel programming mode: problem class, diagnostic
+PANEL_PROGRAMMING_MODE_SCHEMA = binary_sensor.binary_sensor_schema(
+    device_class=DEVICE_CLASS_PROBLEM,
+    icon="mdi:cog-transfer",
+    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+# Trouble active: problem class, diagnostic
+TROUBLE_ACTIVE_SCHEMA = binary_sensor.binary_sensor_schema(
+    device_class=DEVICE_CLASS_PROBLEM,
+    icon="mdi:alert-circle",
+    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_BENTEL_KYO_ID): cv.use_id(BentelKyo),
@@ -297,6 +315,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_COMMUNICATION): COMMUNICATION_SCHEMA,
         cv.Optional(CONF_SIREN): SIREN_SCHEMA,
         cv.Optional(CONF_OUTPUT_STATE): cv.ensure_list(OUTPUT_STATE_SENSOR_SCHEMA),
+        cv.Optional(CONF_PANEL_PROGRAMMING_MODE): PANEL_PROGRAMMING_MODE_SCHEMA,
+        cv.Optional(CONF_TROUBLE_ACTIVE): TROUBLE_ACTIVE_SCHEMA,
     }
 )
 
@@ -398,3 +418,11 @@ async def to_code(config):
             await _register_sensor(hub, out_conf, "OUTPUT_STATE", out_index)
             if CONF_OUTPUT_PANEL_NAME in out_conf:
                 await _register_text_sensor(hub, out_conf[CONF_OUTPUT_PANEL_NAME], "TEXT_OUTPUT_NAME", out_index)
+
+    # Panel programming mode sensor
+    if CONF_PANEL_PROGRAMMING_MODE in config:
+        await _register_sensor(hub, config[CONF_PANEL_PROGRAMMING_MODE], "PANEL_PROGRAMMING_MODE")
+
+    # Trouble active sensor
+    if CONF_TROUBLE_ACTIVE in config:
+        await _register_sensor(hub, config[CONF_TROUBLE_ACTIVE], "TROUBLE_ACTIVE")

--- a/components/bentel_kyo/text_sensor.py
+++ b/components/bentel_kyo/text_sensor.py
@@ -21,6 +21,8 @@ CONF_PARTITIONS = "partitions"
 CONF_PARTITION = "partition"
 CONF_CODES = "codes"
 CONF_CODE = "code"
+CONF_PANEL_MODE_RAW = "panel_mode_raw"
+CONF_STATUS_FLAGS_RAW = "status_flags_raw"
 
 TextSensorType = bentel_kyo_ns.enum("TextSensorType")
 
@@ -69,6 +71,14 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_KEYFOBS): cv.ensure_list(KEYFOB_SCHEMA),
         cv.Optional(CONF_PARTITIONS): cv.ensure_list(PARTITION_NAME_SCHEMA),
         cv.Optional(CONF_CODES): cv.ensure_list(CODE_NAME_SCHEMA),
+        cv.Optional(CONF_PANEL_MODE_RAW): text_sensor.text_sensor_schema(
+            icon="mdi:cog-transfer",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_STATUS_FLAGS_RAW): text_sensor.text_sensor_schema(
+            icon="mdi:alert-circle-outline",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
     }
 )
 
@@ -110,3 +120,13 @@ async def to_code(config):
             var = await text_sensor.new_text_sensor(code_conf)
             cg.add(var.set_disabled_by_default(True))
             cg.add(hub.register_text_sensor(var, TextSensorType.TEXT_CODE_NAME, code_index))
+
+    if CONF_PANEL_MODE_RAW in config:
+        var = await text_sensor.new_text_sensor(config[CONF_PANEL_MODE_RAW])
+        cg.add(var.set_disabled_by_default(True))
+        cg.add(hub.register_text_sensor(var, TextSensorType.TEXT_PANEL_MODE_RAW, 0))
+
+    if CONF_STATUS_FLAGS_RAW in config:
+        var = await text_sensor.new_text_sensor(config[CONF_STATUS_FLAGS_RAW])
+        cg.add(var.set_disabled_by_default(True))
+        cg.add(hub.register_text_sensor(var, TextSensorType.TEXT_STATUS_FLAGS_RAW, 0))

--- a/espkyogate_configuration.yaml
+++ b/espkyogate_configuration.yaml
@@ -280,6 +280,34 @@ text_sensor:
         name: "Keyfob 1"
       - slot: 2
         name: "Keyfob 2"
+    partitions:
+      - partition: 1
+        name: "Partition 1 Name"
+      - partition: 2
+        name: "Partition 2 Name"
+    codes:
+      - code: 1
+        name: "Code 1 Name"
+      - code: 2
+        name: "Code 2 Name"
+
+# ========================================
+# Buttons
+# ========================================
+
+button:
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: reread_config
+    name: "Reread Panel Config"
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: reset_alarms
+    name: "Reset Alarms"
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: read_event_log
+    name: "Read Event Log"
 
 sensor:
   - platform: uptime

--- a/tests/test_invalid_output_number.yaml
+++ b/tests/test_invalid_output_number.yaml
@@ -1,5 +1,5 @@
 # Test: Invalid output number should fail schema validation
-# Validates: output_number > 8 is rejected
+# Validates: output_number > 16 is rejected
 
 external_components:
   - source:
@@ -46,5 +46,5 @@ binary_sensor:
   - platform: bentel_kyo
     bentel_kyo_id: kyo
     output_state:
-      - output_number: 9
-        name: "Invalid Output 9"
+      - output_number: 17
+        name: "Invalid Output 17"


### PR DESCRIPTION
## Summary

- Decode the 16-bit event codes in the panel's event log into human-readable names with 19 event types and model-dependent tables (KYO32 vs KYO4/8)
- Fix model-dependent siren and output parsing per the partition status byte layout — KYO32 now parses all 16 outputs, KYO4/8 models use correct siren bit position
- Add Panel Mode (0x01E6) and Status Flags (0x1503) register reads as binary_sensor and text_sensor entities for programming mode detection and trouble monitoring

## Changes

| Commit | Files | Description |
|--------|-------|-------------|
| `da2a9d8` | cpp, h, PROTOCOL.md, README.md, yaml | Initial event log type code decoding with 10 confirmed types |
| `90fffb2` | cpp, binary_sensor.py | Fix siren/output bit positions per model; allow outputs 1-16 |
| `77258d3` | h, cpp, binary_sensor.py, text_sensor.py | Add panel_programming_mode, trouble_active, panel_mode_raw, status_flags_raw |
| `2269922` | h, cpp | Expand event table to 19 types, model-dependent KYO32/KYO4/8 tables |

## Test plan

- [ ] Press "Read Event Log" button and verify decoded event names in ESPHome logs
- [ ] Confirm new event types (Zone Bypass, Tamper Zone, Recognized Key, etc.) decode correctly
- [ ] Verify unknown event codes display as `Unknown (0x083F)` format
- [ ] Check `Panel mode: 11 10` debug line appears during config read
- [ ] Check `Status flags: FF FF FF FF FF` debug line appears during config read
- [ ] Verify output state parsing for all 16 outputs on KYO32 (non-G returns 0xFF for both bytes)
- [ ] Validate YAML config compiles without errors with all new entities