### PR TITLE
Fix KYO8 panels rejected for returning 18-byte sensor responses

### DIFF
--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -377,13 +377,21 @@ bool BentelKyo::parse_sensor_status_(const uint8_t *rx, int count) {
   bool is_kyo8 = (this->alarm_model_ == AlarmModel::KYO_8 || this->alarm_model_ == AlarmModel::KYO_4 ||
                   this->alarm_model_ == AlarmModel::KYO_8G || this->alarm_model_ == AlarmModel::KYO_8W);
 
-  // Validate response length matches detected model (or infer model if not yet detected)
-  int expected_len = is_kyo8 ? RESP_SENSOR_KYO8 : RESP_SENSOR_KYO32;
+  // Determine parsing format from response length (12 = KYO8 format, 18 = KYO32 format).
+  // Some panels report one model via firmware but use a different response format,
+  // so always trust the response length for parsing.
   if (this->model_detected_) {
+    int expected_len = is_kyo8 ? RESP_SENSOR_KYO8 : RESP_SENSOR_KYO32;
     if (count != expected_len) {
-      ESP_LOGE(TAG, "Sensor status: expected %d bytes for %s model, got %d",
-               expected_len, is_kyo8 ? "KYO8" : "KYO32", count);
-      return false;
+      if (count == RESP_SENSOR_KYO32 || count == RESP_SENSOR_KYO8) {
+        is_kyo8 = (count == RESP_SENSOR_KYO8);
+        ESP_LOGW(TAG, "Sensor status: %s firmware returned %d-byte response, parsing as %s format",
+                 is_kyo8 ? "KYO32" : "KYO8", count, is_kyo8 ? "KYO8" : "KYO32");
+      } else {
+        ESP_LOGE(TAG, "Sensor status: expected %d bytes for %s model, got %d",
+                 expected_len, is_kyo8 ? "KYO8" : "KYO32", count);
+        return false;
+      }
     }
   } else {
     // Model not yet detected — infer from response length


### PR DESCRIPTION
## Summary
- Some KYO8 panels return 18-byte sensor status responses (KYO32 format) despite identifying as KYO8 via firmware string
- The strict size validation rejected these as errors, causing complete communication failure ("Panel not responding, retrying in 32s")
- Trust the actual response length to determine parsing format instead of hard-failing on model/size mismatch

Fixes #85

## How to test
1. Update `espkyogate_configuration.yaml` to point to this branch:
   ```yaml
   external_components:
     - source: github://ruimarinho/espkyogate@bugfix/kyo8-sensor-response-size
       components: [bentel_kyo]
   ```
2. Clean build files and re-flash the device
3. Check the ESPHome logs — the `Sensor status: expected 12 bytes for KYO8 model, got 18` error should no longer appear
4. If your panel returns a mismatched size, you should see a one-time warning like:
   `Sensor status: KYO8 firmware returned 18-byte response, parsing as KYO32 format`
5. Verify zones, partitions and warnings report correct states in Home Assistant