### PR TITLE
Fix KYO8W arming state: read partition status with the KYO32 protocolAdd files via upload

### DIFF
--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -146,7 +146,7 @@ void BentelKyo::loop() {
         const uint8_t *cmd;
         int cmd_len;
         if (this->alarm_model_ == AlarmModel::KYO_8 || this->alarm_model_ == AlarmModel::KYO_4 ||
-            this->alarm_model_ == AlarmModel::KYO_8G || this->alarm_model_ == AlarmModel::KYO_8W) {
+            this->alarm_model_ == AlarmModel::KYO_8G) {
           cmd = CMD_GET_PARTITION_KYO8; cmd_len = sizeof(CMD_GET_PARTITION_KYO8);
         } else {
           // KYO32 and KYO32G use the same partition status command
@@ -557,7 +557,7 @@ bool BentelKyo::parse_sensor_status_(const uint8_t *rx, int count) {
 
 bool BentelKyo::parse_partition_status_(const uint8_t *rx, int count) {
   bool is_kyo8 = (this->alarm_model_ == AlarmModel::KYO_8 || this->alarm_model_ == AlarmModel::KYO_4 ||
-                  this->alarm_model_ == AlarmModel::KYO_8G || this->alarm_model_ == AlarmModel::KYO_8W);
+                  this->alarm_model_ == AlarmModel::KYO_8G);
 
   int expected_len = is_kyo8 ? RESP_PARTITION_KYO8 : RESP_PARTITION_KYO32;
   if (count != expected_len) {


### PR DESCRIPTION
## Problem
On a **Bentel KYO8W** (firmware `KYO8W 2.13`) the integration reports the wrong
arming state in Home Assistant:
- the panel shows **armed when it is actually disarmed**;
- **arming one area arms all areas**;
- **false zone alarm/tamper memories** appear.

## Root cause
`KYO_8W` is grouped with `KYO_8 / KYO_4 / KYO_8G` for partition handling, so it
uses the **KYO8 partition command/parser** (`CMD_GET_PARTITION_KYO8`, register
`0x0E68`, 17-byte response). But the KYO8W actually speaks the **KYO32 dialect**
for partition status (`CMD_GET_PARTITION_KYO32`, register `0x1502`, 26-byte
response). Reading the arming/zone bits from the wrong frame layout produces all
the symptoms above.

(The sensor-status parser already self-corrects to KYO32 by response length — see
the `Sensor status: ... parsing as KYO32 format` warning — but the partition
parser does not.)

## Fix
Remove `KYO_8W` from the "KYO8 group" in two places in `bentel_kyo.cpp` so a
KYO8W is read with the KYO32 partition command and 26-byte parser:
1. partition-command selection — KYO8W now sends `CMD_GET_PARTITION_KYO32`;
2. `is_kyo8` in `parse_partition_status_` — KYO8W now expects the 26-byte KYO32
   response and uses the KYO32 byte offsets.

## Testing
Tested on real KYO8W hardware (fw `KYO8W 2.13`, ESPHome 2026.5.x, ESP32 + LAN8720):
- disarm all → all three area `alarm_control_panel` entities report **disarmed**;
- arm only Area 1 → **only** Area 1 shows armed, Areas 2/3 stay disarmed;
- no false zone alarm/tamper memories.

Related to #107.