### PR TITLE
Fix KYO32G false programming/trouble flags from mismapped registers

### DIFF
--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1473,6 +1473,15 @@ void BentelKyo::read_panel_mode_() {
     // the continuous F0 68 status poll.
     return;
   }
+  if (this->alarm_model_ == AlarmModel::KYO_32G) {
+    // 0x01E6 is not the panel-mode register on KYO32G. A full config scan of a KYO32G 2.13
+    // shows the 32-zone config table filling 0x009F-0x011E and the zone-enrollment table at
+    // 0x019E-0x01F7, so 0x01E6 lands inside enrollment (reads FF 00 = the 2nd byte of a zone
+    // record). Against the {0x11,0x10} idle baseline that is a permanent false programming=YES.
+    // Leave panel_programming_mode_ at its idle default; the correct KYO32G register, if any,
+    // still needs a programming-mode differential capture to locate.
+    return;
+  }
   uint8_t rx[255];
   int count = this->read_register_(0x01E6, 0x02, rx, 300);
   if (count < 6 + 2) {
@@ -1495,6 +1504,14 @@ void BentelKyo::read_status_flags_() {
     // 0x1503 reads ASCII text, not trouble bit-flags, on KYO8 2.04, which the "any byte
     // != 0xFF" rule reads as a permanent false trouble=YES (issue #113). Leave
     // trouble_active_ at its no-trouble default until the real register is located.
+    return;
+  }
+  if (this->alarm_model_ == AlarmModel::KYO_32G) {
+    // 0x1503 is not the trouble-flags register on KYO32G. The 2.13 scan shows this address
+    // sits in the FF padding just after the partition-status block (0x14EC/0x1502 on the G),
+    // reading 00 00 FF 00 FF; the "any byte != 0xFF" rule turns that into a permanent false
+    // trouble=YES. Leave trouble_active_ at its no-trouble default. Real faults still surface
+    // through the WARNING_* binary sensors parsed from the live status poll.
     return;
   }
   uint8_t rx[255];

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1478,8 +1478,10 @@ void BentelKyo::read_panel_mode_() {
     // shows the 32-zone config table filling 0x009F-0x011E and the zone-enrollment table at
     // 0x019E-0x01F7, so 0x01E6 lands inside enrollment (reads FF 00 = the 2nd byte of a zone
     // record). Against the {0x11,0x10} idle baseline that is a permanent false programming=YES.
-    // Leave panel_programming_mode_ at its idle default; the correct KYO32G register, if any,
-    // still needs a programming-mode differential capture to locate.
+    // Leave panel_programming_mode_ at its idle default. A programming-mode differential can't
+    // locate the real register either: on KYO32G (as on KYO8) entering the installer menu
+    // silences the serial bus entirely, so the communication-status sensor is the only
+    // observable signal for that state.
     return;
   }
   uint8_t rx[255];

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1537,8 +1537,11 @@ labels rather than the configured names.
 | `0x01E6` | Panel mode | Inside the zone-enrollment table `0x019E`-`0x01F7` (reads `FF 00`, the 2nd byte of a zone record) | Permanent false `programming=YES` |
 | `0x1503` | Status flags | `FF` padding just after partition status `0x14EC`/`0x1502` (reads `00 00 FF 00 FF`) | Permanent false `trouble=YES` |
 
-The correct KYO32G panel-mode / trouble registers, if they exist, need a
-programming-mode differential to locate. Real faults still surface through the
+The correct KYO32G panel-mode / trouble registers, if they exist, cannot be
+located with a programming-mode differential: on KYO32G — exactly as observed
+on KYO8 2.04 — entering the installer menu silences the serial bus entirely,
+so programming mode is only observable as a communication loss (the
+communication-status sensor). Real faults still surface through the
 `WARNING_*` binary sensors parsed from the live status poll, so gating these two
 reads loses no genuine fault detection.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1494,6 +1494,54 @@ KyoUnit during upload/download operations. Subject to the same
 | `0xC045` | 96B | Zone ESN storage (32 × 3 bytes) | Yes |
 | `0xC0B1` | 48B | Keyfob ESN storage (16 × 3 bytes) | Yes |
 
+### 10.28 KYO32G 2.13 Configuration Map (full-scan reference)
+
+First complete scan of a KYO32G's configuration space (firmware `KYO32G  2.13`),
+captured with the `memory_scan` debug button. Sections 10.1-10.27 above describe
+the KYO32/KYO32M (non-G); the differences below apply to the G and were all
+cross-checked against the live entities the component publishes.
+
+**Active configuration** (read correctly by the component's KYO32G path):
+
+| Content | KYO32G address (observed) | Notes |
+|---------|---------------------------|-------|
+| Zone config | `0x009F` (32 × 4) | Same base as non-G; byte 0 = type, byte 2 = area mask (validated against `Zone N Partition` sensors) |
+| Timers | `0x016F` | All eight areas' entry/exit + siren, areas 5-8 included and correct |
+| Partition names | `0x1750` (8 × 16) | |
+| Zone names | zones 17-32 observed at `0x1AB0`-`0x1BAF`; the 1-16 table precedes it (~`0x19B0`) | |
+| Code names | `0x1BB0` (24 × 16) | |
+| Keyfob / digital-key names | `0x1D30` (16 × 16) | |
+| Output names | `0x1E30` (16 × 16) | |
+| Zone ESN | `0xC045`+ | |
+| Keyfob ESN | `0xC0B1`+ | |
+
+These active name tables differ from the non-G addresses in 10.2 / 10.6-10.13
+(`0x2Exx` / `0x3xxx`). On the G those non-G addresses instead fall inside a
+built-in string ROM (below), so the component uses model-specific bases.
+
+**Built-in string ROM `0x2BA0`-`0x3820`.** Holds the panel's default entity
+labels (`Reader NN`, `Zone N`, `User Code N`, `Key/Card N`, `Output N`,
+`Telephone numb.N`) followed by the full UI menu/option string set (language
+menu, `PROGRAMMING`, `Ready`, `Times`, `Codes`, `Instant`/`Delayed`/`Path`,
+`NC`/`NO`/`BAL`/`DBAL`/`Cycles`, weekday abbreviations, trouble names, …). It is
+distinct from the active, user-editable name tables above, which carry the
+panel's localized defaults (e.g. Italian `Zona N`). A zero-config read of the
+non-G name addresses lands in this ROM, which is why it returns clean English
+labels rather than the configured names.
+
+**Two register mismappings on the G** (gated off for `KYO_32G` in
+`read_panel_mode_` / `read_status_flags_`):
+
+| Register | Non-G meaning | On KYO32G 2.13 | Effect if read |
+|----------|---------------|----------------|----------------|
+| `0x01E6` | Panel mode | Inside the zone-enrollment table `0x019E`-`0x01F7` (reads `FF 00`, the 2nd byte of a zone record) | Permanent false `programming=YES` |
+| `0x1503` | Status flags | `FF` padding just after partition status `0x14EC`/`0x1502` (reads `00 00 FF 00 FF`) | Permanent false `trouble=YES` |
+
+The correct KYO32G panel-mode / trouble registers, if they exist, need a
+programming-mode differential to locate. Real faults still surface through the
+`WARNING_*` binary sensors parsed from the live status poll, so gating these two
+reads loses no genuine fault detection.
+
 ---
 
 ## 11. Known Issues and Unmapped Data


### PR DESCRIPTION
## Problem

On KYO32G the component permanently reports **programming mode = ON** and **trouble = ON** even with the panel idle and fault-free:

```
[bentel_kyo]: Panel mode: FF 00 (programming=YES)
[bentel_kyo]: Status flags: 00 00 FF 00 FF (trouble=YES)
```

Both flags come from fixed registers that are mapped differently on the G. A full configuration scan of a KYO32G 2.13 (captured with the `memory_scan` debug helper from #113) shows:

- `0x01E6` (panel mode on non-G) lands **inside the zone-enrollment table** `0x019E`-`0x01F7` on the G — it reads `FF 00`, the second byte of a zone record, which the `{0x11,0x10}` idle-baseline check flags as programming=YES forever.
- `0x1503` (status flags on non-G) sits in the `FF` **padding right after the partition-status block** (`0x14EC`/`0x1502` on the G) — it reads `00 00 FF 00 FF`, which the "any byte != 0xFF" rule flags as trouble=YES forever.

This is the same family of G-vs-non-G divergence already known for partition status (`0x1502` vs `0x14EC`).

## Changes

- `read_panel_mode_()` / `read_status_flags_()`: early-return for `AlarmModel::KYO_32G`, leaving the idle / no-trouble defaults. The KYO32 (non-G) path is untouched.
- No fault detection is lost: real faults keep surfacing through the `WARNING_*` binary sensors parsed from the live status poll, and programming mode is not detectable via register read anyway — on KYO32G (verified on the owner's panel, same as KYO8 2.04) entering the installer menu silences the serial bus entirely, so the communication-status sensor is the only observable signal for that state.
- Docs: new PROTOCOL.md §10.28 — first complete KYO32G 2.13 configuration map from the scan: active name tables at `0x17xx`-`0x1Exx` (different from the non-G `0x2Exx`/`0x3xxx` bases), the built-in string ROM at `0x2BA0`-`0x3820` (default labels + UI strings, which is what a non-G-address read returns on the G), and the two register mismappings above.

## Validation

Scanned and validated on a live KYO32G 2.13: zone config, all-8-areas timers at `0x016F`, and every name table cross-checked against the entities the component publishes. The gating removes the two false flags; everything else on the G path is unchanged. Compile-tested with ESP-IDF (esp32dev).

Independent of #115 (KYO8 register map) — branched directly off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
