### PR TITLE
debug: memory_scan button — read-only config-space dump for protocol mapping (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .pioenvs
 .piolibdeps
 .vscode/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ button:
 | `reread_config` | Re-read zone configuration, names, serial numbers from panel |
 | `reset_alarms` | Reset alarm memory on the panel |
 | `read_event_log` | Read panel event log (256 entries) with decoded event names and dump to ESPHome logs |
+| `memory_scan` | Debug: dump the panel's configuration memory to the ESPHome log for protocol mapping |
 | `arm_all_away` | Arm all registered partitions in Away mode |
 | `arm_all_home` | Arm all registered partitions in Home/Stay mode |
 | `arm_all_night` | Arm all registered partitions in Night mode |
@@ -535,6 +536,38 @@ Event [253]: 01-03-2026 11:36  Disarm Partition n.1
 ```
 
 <img src="images/ESPHomeLogs.png" alt="ESPHome Event Logs" width="600px"/>
+
+### Memory Scan (debug)
+
+The `memory_scan` button is a protocol-mapping aid: it reads the documented
+configuration address ranges (92 x 64-byte chunks, about one minute at the
+default 500ms polling) and dumps them to the ESPHome log as hex+ASCII `SCAN`
+lines. It only issues the same `0xF0` read command used for normal
+configuration reads — nothing is written to the panel, and status polling keeps
+running between chunks, so the panel stays reachable throughout.
+
+```yaml
+button:
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: memory_scan
+    name: "Memory Scan (Debug)"
+```
+
+Press the button once with the panel idle, then copy the `SCAN 0x....` lines
+from the log. Typical use is comparing two dumps taken before and after
+changing a single panel setting to locate the register it lives in
+(see `docs/PROTOCOL.md`).
+
+**The dump contains personal data** — the event log, code and phone-book
+names, access PINs and phone numbers. Redact those lines before attaching a
+scan to a public issue (the log prints a reminder at scan start and end).
+
+Notes:
+- On KYO8 the first chunk (`0x0000`) is not readable and logs a warning — this
+  is expected and harmless.
+- Individual chunk failures are logged and skipped; the scan always runs to
+  completion.
 
 ### Arm Preset Buttons
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1288,16 +1288,26 @@ void BentelKyo::read_partition_config_() {
   // Bytes 0-15: entry/exit timers (2 bytes per partition: entry, exit) for 8 partitions
   // Bytes 16-23: siren duration (1 byte per partition)
   if (this->is_kyo8_family_()) {
-    // On KYO8 2.04, 0x016F returns an index table (00 00 01 0X FF FF), not timers
-    // (issue #113). The memory scan places the real area timers around 0x00DC-0x00EF,
-    // right after the zone-config block (all configured values match there), but the
-    // per-field layout is unconfirmed — a differential capture (change one timer,
-    // rescan) is needed before decoding. Skip until then, leaving the defaults.
-    // Logged once per config read (not in the ~60s periodic republish, so no spam).
-    ESP_LOGW(TAG,
-             "Partition timers: register layout not yet decoded for firmware '%s' — skipped. See "
-             "https://github.com/lorenzo-deluca/espkyogate/issues/113",
-             this->firmware_version_);
+    // KYO8 2.04 keeps the area timers right after the zone-config block, not at 0x016F
+    // (which returns an index table on this firmware). Layout confirmed by a differential
+    // capture on issue #113 (P1 exit 30s->25s flipped exactly 0x00DC from 1E to 19):
+    //   0x00DC-0x00DF: exit delay P1-P4 (seconds)
+    //   0x00E0-0x00E3: entry delay P1-P4 (seconds)
+    //   0x00E4-0x00E7: pre-alarm P1-P4 (minutes, not currently exposed)
+    // The siren-duration byte has not been identified yet — it stays at its default and
+    // the siren text sensor publishes "N/A" on this family.
+    uint8_t rx[255];
+    int count = this->read_register_(0x00DC, 0x08, rx, 300);
+    if (count < 6 + 8) {
+      ESP_LOGW(TAG, "KYO8 timer read at 0x00DC failed: got %d bytes", count);
+      return;
+    }
+    for (int i = 0; i < KYO_PARTITIONS_8; i++) {
+      this->partition_exit_delay_[i] = rx[6 + i];
+      this->partition_entry_delay_[i] = rx[6 + 4 + i];
+      ESP_LOGD(TAG, "Partition %d: entry=%ds, exit=%ds", i + 1,
+               this->partition_entry_delay_[i], this->partition_exit_delay_[i]);
+    }
     return;
   }
   uint8_t rx[255];
@@ -1670,17 +1680,20 @@ void BentelKyo::publish_text_sensors_() {
         if (idx >= KYO_MAX_KEYFOBS) continue;
         entry.sensor->publish_state(this->keyfob_name_[idx].empty() ? "N/A" : this->keyfob_name_[idx]);
         break;
-      // Partition timers come from 0x016F, which is unmapped on the KYO8 family (issue #113);
-      // publish "N/A" there instead of the default 0 so the value isn't mistaken for a real one.
+      // On the KYO8 family entry/exit delays are decoded from 0x00DC for partitions 1-4
+      // (issue #113); higher partition slots and the siren duration (byte not yet
+      // identified) publish "N/A" so a default 0 isn't mistaken for a real value.
       case TEXT_PARTITION_ENTRY_DELAY:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
-                                                            : to_string(this->partition_entry_delay_[idx]) + "s");
+        entry.sensor->publish_state(this->is_kyo8_family_() && idx >= KYO_PARTITIONS_8
+                                        ? "N/A"
+                                        : to_string(this->partition_entry_delay_[idx]) + "s");
         break;
       case TEXT_PARTITION_EXIT_DELAY:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
-                                                            : to_string(this->partition_exit_delay_[idx]) + "s");
+        entry.sensor->publish_state(this->is_kyo8_family_() && idx >= KYO_PARTITIONS_8
+                                        ? "N/A"
+                                        : to_string(this->partition_exit_delay_[idx]) + "s");
         break;
       case TEXT_PARTITION_SIREN_TIMER:
         if (idx >= KYO_MAX_PARTITIONS) continue;

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1680,17 +1680,19 @@ bool BentelKyo::read_event_log_next_() {
 // one 64-byte read per update() cycle, as hex + printable ASCII rows (16 bytes per row,
 // matching the 16-byte name-slot size so label tables line up visually).
 //
-// Regions scanned:
-// - 0x3380-0x35FF: continuation of the KYO8 user-label table. Zone (0x3250), area (0x32D0)
-//   and keypad (0x3310) labels are known; output/keyfob/code names should follow here.
-// - 0x00DF-0x021E: region after the zone-config block 0x009F, where the KYO8 area timers
-//   (Tempi -> Aree) are expected, spanning the 0x016F index table and 0x01E6 neighborhood.
+// Regions scanned (v2 — updated after the first scan mapped 0x3380-0x35FF and 0x00DF-0x021E):
+// - 0x3600-0x37FF: past the end of the known label table (zones 0x3250, areas 0x32D0,
+//   keypads 0x3310, readers 0x3390, codes 0x3490-0x35FF). Output and keyfob labels were
+//   not in the scanned range and, if they exist, should be here.
+// - 0x00DF: the area-timer block found by the first scan (values match the configured
+//   timers but the field layout is unconfirmed). Kept so a differential capture — change
+//   one timer on the keypad, rescan, diff this row — can pin each field.
 bool BentelKyo::memory_scan_next_() {
   static const uint16_t SCAN_ADDRS[] = {
-      // label-table continuation
-      0x3380, 0x33C0, 0x3400, 0x3440, 0x3480, 0x34C0, 0x3500, 0x3540, 0x3580, 0x35C0,
-      // timer / fixed-register neighborhood
-      0x00DF, 0x011F, 0x015F, 0x019F, 0x01DF,
+      // label-table continuation past the code names
+      0x3600, 0x3640, 0x3680, 0x36C0, 0x3700, 0x3740, 0x3780, 0x37C0,
+      // area-timer block, for differential timer capture
+      0x00DF,
   };
   static const int SCAN_CHUNKS = sizeof(SCAN_ADDRS) / sizeof(SCAN_ADDRS[0]);
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1680,27 +1680,53 @@ bool BentelKyo::read_event_log_next_() {
 // one 64-byte read per update() cycle, as hex + printable ASCII rows (16 bytes per row,
 // matching the 16-byte name-slot size so label tables line up visually).
 //
-// Regions scanned (v3 — the label table is fully mapped; only the timer block remains):
-// - 0x009F + 0x00DF: contiguous coverage of 0x009F-0x011E. The v2 scan started at 0x00DF
-//   and missed the 3-byte blind spot 0x00DC-0x00DE, only reachable through the tail of the
-//   0x009F zone-config read — a differential capture (P1 exit 30s->25s) changed nothing in
-//   0x00DF+, placing P1 exit exactly in that blind spot. Working layout hypothesis:
-//   exit P1-P4 @ 0x00DC, entry P1-P4 @ 0x00E0, pre-alarm @ 0x00E4, then 05x4 and 0Ax4.
+// Regions scanned (v5 — full sweep of the documented config space, for cross-model
+// comparison; the goal is a complete map on every model, not just KYO8):
+// - 0x0000-0x09FF: core configuration. Covers everything in PROTOCOL.md section 10 up to
+//   the end of event routing (0x0921) — zone config, keyfob buttons, timers, enrollment,
+//   partition/code config, panel options, ARC phone numbers — plus the undocumented
+//   0x0000-0x009E head. On KYO8 this includes the whole 9.2 timer/telephony block.
+// - 0x14C0-0x153F: runtime status region (partition status 0x14EC/0x1502, status flags
+//   0x1503-0x1509). Bytes here change with panel state, so diffs are only meaningful for
+//   config-differential captures if the panel state is otherwise unchanged.
+// - 0x2BA0-0x381F: all name tables on both map families (KYO32 non-G: 0x2BA0-0x347F,
+//   sections 10.2/10.6-10.13; KYO8 2.04: 0x3250-0x37EF, section 9.2).
+// Deliberately excluded: the event log (0x0D27-0x1426, dumpable via the read_event_log
+// button) and the slow 0xC0xx EEPROM windows (~1.5s per read, already handled by the
+// ESN readers). Reads of addresses a model doesn't answer for fail after the timeout and
+// are logged and skipped — the scan always runs to completion.
 bool BentelKyo::memory_scan_next_() {
-  static const uint16_t SCAN_ADDRS[] = {
-      // zone-config block + timer region, contiguous (covers the 0x00DC-0x00DE blind spot)
-      0x009F, 0x00DF,
+  struct ScanRange {
+    uint16_t start;
+    uint8_t chunks;  // number of 64-byte reads
   };
-  static const int SCAN_CHUNKS = sizeof(SCAN_ADDRS) / sizeof(SCAN_ADDRS[0]);
+  static const ScanRange SCAN_RANGES[] = {
+      {0x0000, 40},  // 0x0000-0x09FF core config
+      {0x14C0, 2},   // 0x14C0-0x153F status region
+      {0x2BA0, 50},  // 0x2BA0-0x381F name tables
+  };
+  static const int SCAN_RANGE_COUNT = sizeof(SCAN_RANGES) / sizeof(SCAN_RANGES[0]);
+
+  int total_chunks = 0;
+  for (int r = 0; r < SCAN_RANGE_COUNT; r++)
+    total_chunks += SCAN_RANGES[r].chunks;
 
   int chunk = this->memory_scan_chunk_index_;
-  if (chunk >= SCAN_CHUNKS) {
+  if (chunk >= total_chunks) {
     ESP_LOGI(TAG, "Memory scan complete — please attach the SCAN lines above to issue #113");
     return true;
   }
 
-  uint16_t addr = SCAN_ADDRS[chunk];
-  ESP_LOGI(TAG, "Memory scan chunk %d/%d (0x%04X)", chunk + 1, SCAN_CHUNKS, addr);
+  uint16_t addr = 0;
+  int rem = chunk;
+  for (int r = 0; r < SCAN_RANGE_COUNT; r++) {
+    if (rem < SCAN_RANGES[r].chunks) {
+      addr = SCAN_RANGES[r].start + (uint16_t) (rem * 64);
+      break;
+    }
+    rem -= SCAN_RANGES[r].chunks;
+  }
+  ESP_LOGI(TAG, "Memory scan chunk %d/%d (0x%04X)", chunk + 1, total_chunks, addr);
 
   uint8_t rx[255];
   int count = this->read_register_(addr, 0x3F, rx, 500);

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1130,9 +1130,13 @@ bool BentelKyo::read_zone_config_() {
     // KYO8 2.04 prefixes the block with a 4-byte header, so zone records start at 0x00A3
     // instead of 0x009F (issue #113 validation: with the shift, every zone lands in the
     // area configured on the panel; without it zone 1 reads area 0x00 = "None").
-    // KYO8 record bytes, cross-checked against the Bentel Security Suite zone page:
-    // [0]=type, [1]=unknown (always 0x00, NOT a wireless-enrolled flag), [2]=area mask,
-    // [3]=alarm-cycle count (0-14; 0x0F = repetitive/unlimited).
+    // KYO8 record bytes, confirmed by Suite-vs-scan differentials on firmware 2.04:
+    // [0]=type in the low bits (0x00 Instant, 0x01 Delayed, 0x02 Path) plus wiring/balance
+    // in the high bits (Normally Closed = 0x00, Normally Open = +0x08), [1]=zone attribute
+    // bitmask (Internal = 0x20; 0x00 = no attributes set — NOT a wireless-enrolled flag),
+    // [2]=area mask, [3]=alarm-cycle count (0-14; 0x0F = repetitive/unlimited).
+    // Note the layout differs from KYO32 (section 10.1 of PROTOCOL.md), where [1] is the
+    // enrolled flag and [3] is the attribute byte.
     // The header also means only 15 full records fit in the 64 returned bytes — cap the
     // loop so a hypothetical >8-zone KYO8 read can never index past the buffer.
     bool kyo8 = this->is_kyo8_family_();

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1271,11 +1271,16 @@ bool BentelKyo::read_output_names_() {
   // via an on-device memory scan (issue #93).
   static const uint16_t BASE_ADDRS_NONG[] = {0x3280, 0x32C0, 0x3300, 0x3340};
   static const uint16_t BASE_ADDRS_32G[] = {0x1E30, 0x1E70, 0x1EB0, 0x1EF0};
-  // KYO8 output-name location not yet known (issue #113): the memory scan mapped the
-  // user-label table 0x3250-0x35FF (zones, areas, keypads, readers, codes) and it holds
-  // no output labels — they may follow the code names at 0x3600+. Skip until located.
-  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
-  return this->read_name_table_chunk_(bases, 4, KYO_MAX_OUTPUTS, this->output_name_, "Output");
+  // KYO8 2.04: output names live at 0x3710, after the activator labels 0x3610-0x370F, in
+  // the contiguous user-label table (issue #113 memory scan). KYO4/8 expose 5 outputs
+  // (status bits 0-4), so two 64-byte blocks cover slots 1-5; 0x3760+ holds phone-number
+  // labels, which is why only 5 slots are read.
+  static const uint16_t BASE_ADDRS_KYO8[] = {0x3710, 0x3750};
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
+  bool kyo8 = this->is_kyo8_family_();
+  int num_blocks = kyo8 ? 2 : 4;
+  int count = kyo8 ? KYO_OUTPUTS_8 : KYO_MAX_OUTPUTS;
+  return this->read_name_table_chunk_(bases, num_blocks, count, this->output_name_, "Output");
 }
 
 void BentelKyo::read_partition_config_() {
@@ -1358,10 +1363,14 @@ bool BentelKyo::read_keyfob_names_() {
   // at 0x1D30-0x1E2F instead of 0x3180-0x327F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3180, 0x31C0, 0x3200, 0x3240};
   static const uint16_t BASE_ADDRS_32G[] = {0x1D30, 0x1D70, 0x1DB0, 0x1DF0};
-  // KYO8 keyfob-name location not yet known (issue #113): the memory scan shows the label
-  // table holds reader labels ("Lettore 01".."Lettore 16") at 0x3390-0x348F, but no keyfob
-  // (key) labels; they may follow the code names at 0x3600+, or not exist on this firmware.
-  // Skip rather than publish reader labels as keyfob names.
+  // KYO8 2.04 has no per-keyfob name table (issue #113): the memory scan mapped the whole
+  // user-label table 0x3250-0x37EF (zones, areas, keypads, readers, codes, activators,
+  // outputs, phone numbers) and it ends with a single generic "Chiave" slot at 0x37E0,
+  // followed by ROM date-format strings. Skip silently — this is a confirmed absence, not
+  // an unmapped table, so the "please open an issue" warning would be misleading. The
+  // keyfob name sensors stay at "N/A".
+  if (this->is_kyo8_family_())
+    return true;
   const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_KEYFOBS, this->keyfob_name_, "Keyfob");
 }

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1131,8 +1131,15 @@ bool BentelKyo::read_zone_config_() {
     // instead of 0x009F (issue #113 validation: with the shift, zones 1-4 land in area 1
     // and zones 5-6 in area 2, matching the panel's PERIMETRO/VOLUMETRICI assignment;
     // without it zone 1 reads area 0x00 = "None").
-    int base = 6 + (this->is_kyo8_family_() ? 4 : 0);
-    for (int i = 0; i < 16; i++) {
+    // KYO8 record bytes, cross-checked against the Bentel Security Suite zone page:
+    // [0]=type, [1]=unknown (always 0x00, NOT a wireless-enrolled flag), [2]=area mask,
+    // [3]=alarm-cycle count "Cicli" (0-14; 0x0F = "Ripetitivo"/unlimited).
+    // The header also means only 15 full records fit in the 64 returned bytes — cap the
+    // loop so a hypothetical >8-zone KYO8 read can never index past the buffer.
+    bool kyo8 = this->is_kyo8_family_();
+    int base = 6 + (kyo8 ? 4 : 0);
+    int max_recs = kyo8 ? 8 : 16;
+    for (int i = 0; i < max_recs; i++) {
       int z = blk * 16 + i;
       if (z >= this->max_zones_)
         break;
@@ -1302,13 +1309,17 @@ void BentelKyo::read_partition_config_() {
   // Bytes 16-23: siren duration (1 byte per partition)
   if (this->is_kyo8_family_()) {
     // KYO8 2.04 keeps the area timers right after the zone-config block, not at 0x016F
-    // (which returns an index table on this firmware). Layout confirmed by differential
-    // captures on issue #113 (P1 exit 30s->25s flipped exactly 0x00DC; siren 3min->2min
-    // flipped exactly 0x00FA):
-    //   0x00DC-0x00DF: exit delay P1-P4 (seconds)
-    //   0x00E0-0x00E3: entry delay P1-P4 (seconds)
-    //   0x00E4-0x00E7: pre-alarm P1-P4 (minutes, not currently exposed)
-    //   0x00FA:        siren duration, single global byte (minutes)
+    // (which returns an index table on this firmware). Layout pinned by differential
+    // captures and cross-checked against the Bentel Security Suite "Aree" page
+    // (issue #113); official field names:
+    //   0x00DC-0x00DF: "T. Uscita"  — exit delay P1-P4 (seconds)
+    //   0x00E0-0x00E3: "T. Ingresso" — entry delay P1-P4 (seconds)
+    //   0x00E4-0x00E7: "T. Preavviso" — scheduler advance-warning P1-P4 (minutes)
+    //   0x00E8-0x00EB: "T. And Zone" P1-P4 (15-second steps)
+    //   0x00EC-0x00EF: "T. Cod And" P1-P4 (seconds)
+    //   0x00F8:        "Tempo di Ronda" — patrol time (minutes)
+    //   0x00FA:        "Tempo di Allarme" — alarm-cycle/siren duration, global (minutes,
+    //                  0-63; 0 = siren outputs never fire)
     uint8_t rx[255];
     int count = this->read_register_(0x00DC, 0x1F, rx, 300);
     if (count < 6 + 31) {

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1271,8 +1271,9 @@ bool BentelKyo::read_output_names_() {
   // via an on-device memory scan (issue #93).
   static const uint16_t BASE_ADDRS_NONG[] = {0x3280, 0x32C0, 0x3300, 0x3340};
   static const uint16_t BASE_ADDRS_32G[] = {0x1E30, 0x1E70, 0x1EB0, 0x1EF0};
-  // KYO8 output-name location not yet known (issue #113): the 0x3280 block holds the
-  // contiguous zone/partition/keypad label table, not outputs. Skip until located.
+  // KYO8 output-name location not yet known (issue #113): the memory scan mapped the
+  // user-label table 0x3250-0x35FF (zones, areas, keypads, readers, codes) and it holds
+  // no output labels — they may follow the code names at 0x3600+. Skip until located.
   const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_OUTPUTS, this->output_name_, "Output");
 }
@@ -1283,12 +1284,14 @@ void BentelKyo::read_partition_config_() {
   // Bytes 16-23: siren duration (1 byte per partition)
   if (this->is_kyo8_family_()) {
     // On KYO8 2.04, 0x016F returns an index table (00 00 01 0X FF FF), not timers
-    // (issue #113). The real area timers live in/after the 0x009F block. Skip until
-    // decoded, leaving the timer values at their defaults. Logged once per config read
-    // (this function is not in the ~60s periodic republish, so it does not spam).
+    // (issue #113). The memory scan places the real area timers around 0x00DC-0x00EF,
+    // right after the zone-config block (all configured values match there), but the
+    // per-field layout is unconfirmed — a differential capture (change one timer,
+    // rescan) is needed before decoding. Skip until then, leaving the defaults.
+    // Logged once per config read (not in the ~60s periodic republish, so no spam).
     ESP_LOGW(TAG,
-             "Partition timers: register address unknown for firmware '%s' — skipped. Please open "
-             "an issue at https://github.com/lorenzo-deluca/espkyogate with a 'serial_trace' dump.",
+             "Partition timers: register layout not yet decoded for firmware '%s' — skipped. See "
+             "https://github.com/lorenzo-deluca/espkyogate/issues/113",
              this->firmware_version_);
     return;
   }
@@ -1355,8 +1358,10 @@ bool BentelKyo::read_keyfob_names_() {
   // at 0x1D30-0x1E2F instead of 0x3180-0x327F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3180, 0x31C0, 0x3200, 0x3240};
   static const uint16_t BASE_ADDRS_32G[] = {0x1D30, 0x1D70, 0x1DB0, 0x1DF0};
-  // KYO8 keyfob-name location not yet known (issue #113): 0x3180-0x324F reads the LCD
-  // menu-string ROM on this firmware. Skip until located.
+  // KYO8 keyfob-name location not yet known (issue #113): the memory scan shows the label
+  // table holds reader labels ("Lettore 01".."Lettore 16") at 0x3390-0x348F, but no keyfob
+  // (key) labels; they may follow the code names at 0x3600+, or not exist on this firmware.
+  // Skip rather than publish reader labels as keyfob names.
   const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_KEYFOBS, this->keyfob_name_, "Keyfob");
 }
@@ -1385,9 +1390,11 @@ bool BentelKyo::read_code_names_() {
   // at 0x1BB0-0x1D2F instead of 0x3000-0x317F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3000, 0x3040, 0x3080, 0x30C0, 0x3100, 0x3140};
   static const uint16_t BASE_ADDRS_32G[] = {0x1BB0, 0x1BF0, 0x1C30, 0x1C70, 0x1CB0, 0x1CF0};
-  // KYO8 code-name location not yet known (issue #113): 0x3000-0x30BF reads binary config
-  // and 0x30C0+ the LCD menu-string ROM on this firmware. Skip until located.
-  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
+  // KYO8 2.04: code names live at 0x3490, after the reader labels 0x3390-0x348F, in the
+  // contiguous user-label table (located via the issue #113 on-device memory scan; slot 1
+  // matched the panel's configured code name). 24 slots of 16 bytes, 6 blocks of 4.
+  static const uint16_t BASE_ADDRS_KYO8[] = {0x3490, 0x34D0, 0x3510, 0x3550, 0x3590, 0x35D0};
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
   return this->read_name_table_chunk_(bases, 6, KYO_MAX_CODES, this->code_name_, "Code");
 }
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -238,6 +238,7 @@ void BentelKyo::read_event_log() {
 
 void BentelKyo::memory_scan() {
   ESP_LOGI(TAG, "Memory scan requested — dumping unmapped config regions (issue #113)...");
+  ESP_LOGW(TAG, "Scan output contains personal data (event log, code/phone names, access PINs) — redact before sharing");
   this->memory_scan_pending_ = true;
   this->memory_scan_chunk_index_ = 0;
 }
@@ -1713,7 +1714,7 @@ bool BentelKyo::memory_scan_next_() {
 
   int chunk = this->memory_scan_chunk_index_;
   if (chunk >= total_chunks) {
-    ESP_LOGI(TAG, "Memory scan complete — please attach the SCAN lines above to issue #113");
+    ESP_LOGI(TAG, "Memory scan complete — redact personal data, then attach the SCAN lines above to issue #113");
     return true;
   }
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -236,6 +236,12 @@ void BentelKyo::read_event_log() {
   this->event_log_entries_logged_ = 0;
 }
 
+void BentelKyo::memory_scan() {
+  ESP_LOGI(TAG, "Memory scan requested — dumping unmapped config regions (issue #113)...");
+  this->memory_scan_pending_ = true;
+  this->memory_scan_chunk_index_ = 0;
+}
+
 void BentelKyo::set_polling_enabled(bool enabled) {
   if (this->polling_enabled_ == enabled)
     return;
@@ -306,6 +312,13 @@ void BentelKyo::update() {
   if (this->event_log_read_pending_) {
     if (this->read_event_log_next_())
       this->event_log_read_pending_ = false;
+    return;  // Skip normal polling this cycle
+  }
+
+  // On-demand debug memory scan (triggered by memory_scan button, issue #113)
+  if (this->memory_scan_pending_) {
+    if (this->memory_scan_next_())
+      this->memory_scan_pending_ = false;
     return;  // Skip normal polling this cycle
   }
 
@@ -1660,6 +1673,59 @@ bool BentelKyo::read_event_log_next_() {
   }
 
   this->event_log_chunk_index_++;
+  return false;
+}
+
+// Debug helper for issue #113: dumps memory regions whose KYO8 layout is still unknown,
+// one 64-byte read per update() cycle, as hex + printable ASCII rows (16 bytes per row,
+// matching the 16-byte name-slot size so label tables line up visually).
+//
+// Regions scanned:
+// - 0x3380-0x35FF: continuation of the KYO8 user-label table. Zone (0x3250), area (0x32D0)
+//   and keypad (0x3310) labels are known; output/keyfob/code names should follow here.
+// - 0x00DF-0x021E: region after the zone-config block 0x009F, where the KYO8 area timers
+//   (Tempi -> Aree) are expected, spanning the 0x016F index table and 0x01E6 neighborhood.
+bool BentelKyo::memory_scan_next_() {
+  static const uint16_t SCAN_ADDRS[] = {
+      // label-table continuation
+      0x3380, 0x33C0, 0x3400, 0x3440, 0x3480, 0x34C0, 0x3500, 0x3540, 0x3580, 0x35C0,
+      // timer / fixed-register neighborhood
+      0x00DF, 0x011F, 0x015F, 0x019F, 0x01DF,
+  };
+  static const int SCAN_CHUNKS = sizeof(SCAN_ADDRS) / sizeof(SCAN_ADDRS[0]);
+
+  int chunk = this->memory_scan_chunk_index_;
+  if (chunk >= SCAN_CHUNKS) {
+    ESP_LOGI(TAG, "Memory scan complete — please attach the SCAN lines above to issue #113");
+    return true;
+  }
+
+  uint16_t addr = SCAN_ADDRS[chunk];
+  ESP_LOGI(TAG, "Memory scan chunk %d/%d (0x%04X)", chunk + 1, SCAN_CHUNKS, addr);
+
+  uint8_t rx[255];
+  int count = this->read_register_(addr, 0x3F, rx, 500);
+  if (count < 6 + 64) {
+    ESP_LOGW(TAG, "SCAN 0x%04X: read failed (%d bytes) — register may not exist on this panel", addr, count);
+    this->memory_scan_chunk_index_++;
+    return false;
+  }
+
+  // 4 rows of 16 bytes: hex dump + printable ASCII (non-printable -> '.')
+  for (int row = 0; row < 4; row++) {
+    const uint8_t *p = &rx[6 + row * 16];
+    char hex[16 * 3 + 1];
+    char ascii[16 + 1];
+    for (int i = 0; i < 16; i++) {
+      snprintf(&hex[i * 3], 4, "%02X ", p[i]);
+      ascii[i] = (p[i] >= 0x20 && p[i] <= 0x7E) ? (char) p[i] : '.';
+    }
+    hex[16 * 3 - 1] = '\0';
+    ascii[16] = '\0';
+    ESP_LOGI(TAG, "SCAN 0x%04X: %s |%s|", addr + row * 16, hex, ascii);
+  }
+
+  this->memory_scan_chunk_index_++;
   return false;
 }
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1363,15 +1363,13 @@ bool BentelKyo::read_keyfob_names_() {
   // at 0x1D30-0x1E2F instead of 0x3180-0x327F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3180, 0x31C0, 0x3200, 0x3240};
   static const uint16_t BASE_ADDRS_32G[] = {0x1D30, 0x1D70, 0x1DB0, 0x1DF0};
-  // KYO8 2.04 has no per-keyfob name table (issue #113): the memory scan mapped the whole
-  // user-label table 0x3250-0x37EF (zones, areas, keypads, readers, codes, activators,
-  // outputs, phone numbers) and it ends with a single generic "Chiave" slot at 0x37E0,
-  // followed by ROM date-format strings. Skip silently — this is a confirmed absence, not
-  // an unmapped table, so the "please open an issue" warning would be misleading. The
-  // keyfob name sensors stay at "N/A".
-  if (this->is_kyo8_family_())
-    return true;
-  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
+  // KYO8 2.04: keyfob (digital key) names live at 0x3610, labelled "Attivatore 1-16" by
+  // default (issue #113 memory scan). The table sits between the code and output names
+  // with 16 slots — the same relative position and count as the non-G "digital key names"
+  // table (see PROTOCOL.md section 9.1) — "attivatore" being Bentel's term for the digital
+  // keys presented to readers.
+  static const uint16_t BASE_ADDRS_KYO8[] = {0x3610, 0x3650, 0x3690, 0x36D0};
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_KEYFOBS, this->keyfob_name_, "Keyfob");
 }
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1127,11 +1127,16 @@ bool BentelKyo::read_zone_config_() {
   if (count < 6 + 64) {
     ESP_LOGW(TAG, "Zone config read at 0x%04X failed: got %d bytes", BASE_ADDRS[blk], count);
   } else {
+    // KYO8 2.04 prefixes the block with a 4-byte header, so zone records start at 0x00A3
+    // instead of 0x009F (issue #113 validation: with the shift, zones 1-4 land in area 1
+    // and zones 5-6 in area 2, matching the panel's PERIMETRO/VOLUMETRICI assignment;
+    // without it zone 1 reads area 0x00 = "None").
+    int base = 6 + (this->is_kyo8_family_() ? 4 : 0);
     for (int i = 0; i < 16; i++) {
       int z = blk * 16 + i;
       if (z >= this->max_zones_)
         break;
-      int offset = 6 + (i * 4);
+      int offset = base + (i * 4);
       this->zone_type_raw_[z] = rx[offset];
       this->zone_enrolled_[z] = (rx[offset + 1] == 0x01);
       this->zone_area_mask_[z] = rx[offset + 2];
@@ -1224,6 +1229,14 @@ bool BentelKyo::read_zone_esn_next_() {
   // Reads ONE zone per call (one per update cycle) to avoid blocking the main loop.
   // USB capture shows panel takes ~1s to respond to 0xC0xx reads (EEPROM access).
   // Returns true when all zones have been read.
+  if (this->is_kyo8_family_()) {
+    // The 0xC045/0xC0B1 ESN windows read unrelated config data on KYO8 2.04 — a panel
+    // with no wireless receiver returned non-empty "serials", with area-timer bytes
+    // (0F/1E/14) visible in the higher slots (issue #113 validation). Skip; the ESN
+    // sensors stay at "N/A".
+    this->esn_read_index_ = 0;
+    return true;
+  }
   int i = this->esn_read_index_;
 
   if (i >= this->max_zones_) {
@@ -1289,24 +1302,26 @@ void BentelKyo::read_partition_config_() {
   // Bytes 16-23: siren duration (1 byte per partition)
   if (this->is_kyo8_family_()) {
     // KYO8 2.04 keeps the area timers right after the zone-config block, not at 0x016F
-    // (which returns an index table on this firmware). Layout confirmed by a differential
-    // capture on issue #113 (P1 exit 30s->25s flipped exactly 0x00DC from 1E to 19):
+    // (which returns an index table on this firmware). Layout confirmed by differential
+    // captures on issue #113 (P1 exit 30s->25s flipped exactly 0x00DC; siren 3min->2min
+    // flipped exactly 0x00FA):
     //   0x00DC-0x00DF: exit delay P1-P4 (seconds)
     //   0x00E0-0x00E3: entry delay P1-P4 (seconds)
     //   0x00E4-0x00E7: pre-alarm P1-P4 (minutes, not currently exposed)
-    // The siren-duration byte has not been identified yet — it stays at its default and
-    // the siren text sensor publishes "N/A" on this family.
+    //   0x00FA:        siren duration, single global byte (minutes)
     uint8_t rx[255];
-    int count = this->read_register_(0x00DC, 0x08, rx, 300);
-    if (count < 6 + 8) {
+    int count = this->read_register_(0x00DC, 0x1F, rx, 300);
+    if (count < 6 + 31) {
       ESP_LOGW(TAG, "KYO8 timer read at 0x00DC failed: got %d bytes", count);
       return;
     }
+    uint8_t siren_min = rx[6 + 0x1E];  // 0x00FA
     for (int i = 0; i < KYO_PARTITIONS_8; i++) {
       this->partition_exit_delay_[i] = rx[6 + i];
       this->partition_entry_delay_[i] = rx[6 + 4 + i];
-      ESP_LOGD(TAG, "Partition %d: entry=%ds, exit=%ds", i + 1,
-               this->partition_entry_delay_[i], this->partition_exit_delay_[i]);
+      this->partition_siren_timer_[i] = siren_min;
+      ESP_LOGD(TAG, "Partition %d: entry=%ds, exit=%ds, siren=%dmin", i + 1,
+               this->partition_entry_delay_[i], this->partition_exit_delay_[i], siren_min);
     }
     return;
   }
@@ -1333,6 +1348,13 @@ bool BentelKyo::read_keyfob_esn_next_() {
   // Keyfob ESN at 0xC0B1: 3 bytes per keyfob, 16 slots
   // Reads ONE keyfob per call (one per update cycle) to avoid blocking the main loop.
   // Returns true when all keyfobs have been read.
+  if (this->is_kyo8_family_()) {
+    // Same as zone ESNs: the 0xC0B1 window reads unrelated config data on KYO8 2.04
+    // (issue #113 validation — all 16 slots "populated" on a panel with zero keyfobs).
+    // Skip; the keyfob ESN sensors stay at "N/A".
+    this->keyfob_read_index_ = 0;
+    return true;
+  }
   int i = this->keyfob_read_index_;
 
   if (i >= KYO_MAX_KEYFOBS) {
@@ -1680,9 +1702,10 @@ void BentelKyo::publish_text_sensors_() {
         if (idx >= KYO_MAX_KEYFOBS) continue;
         entry.sensor->publish_state(this->keyfob_name_[idx].empty() ? "N/A" : this->keyfob_name_[idx]);
         break;
-      // On the KYO8 family entry/exit delays are decoded from 0x00DC for partitions 1-4
-      // (issue #113); higher partition slots and the siren duration (byte not yet
-      // identified) publish "N/A" so a default 0 isn't mistaken for a real value.
+      // On the KYO8 family the timers are decoded from the 0x00DC block for partitions
+      // 1-4 (issue #113): entry/exit in seconds, siren duration in minutes (one global
+      // byte at 0x00FA, published on each partition slot). Higher partition slots
+      // publish "N/A" so a default 0 isn't mistaken for a real value.
       case TEXT_PARTITION_ENTRY_DELAY:
         if (idx >= KYO_MAX_PARTITIONS) continue;
         entry.sensor->publish_state(this->is_kyo8_family_() && idx >= KYO_PARTITIONS_8
@@ -1697,8 +1720,13 @@ void BentelKyo::publish_text_sensors_() {
         break;
       case TEXT_PARTITION_SIREN_TIMER:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
-                                                            : to_string(this->partition_siren_timer_[idx]));
+        if (this->is_kyo8_family_()) {
+          entry.sensor->publish_state(idx >= KYO_PARTITIONS_8
+                                          ? "N/A"
+                                          : to_string(this->partition_siren_timer_[idx]) + "min");
+        } else {
+          entry.sensor->publish_state(to_string(this->partition_siren_timer_[idx]));
+        }
         break;
       case TEXT_PARTITION_NAME:
         if (idx >= KYO_MAX_PARTITIONS) continue;

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1680,19 +1680,16 @@ bool BentelKyo::read_event_log_next_() {
 // one 64-byte read per update() cycle, as hex + printable ASCII rows (16 bytes per row,
 // matching the 16-byte name-slot size so label tables line up visually).
 //
-// Regions scanned (v2 — updated after the first scan mapped 0x3380-0x35FF and 0x00DF-0x021E):
-// - 0x3600-0x37FF: past the end of the known label table (zones 0x3250, areas 0x32D0,
-//   keypads 0x3310, readers 0x3390, codes 0x3490-0x35FF). Output and keyfob labels were
-//   not in the scanned range and, if they exist, should be here.
-// - 0x00DF: the area-timer block found by the first scan (values match the configured
-//   timers but the field layout is unconfirmed). Kept so a differential capture — change
-//   one timer on the keypad, rescan, diff this row — can pin each field.
+// Regions scanned (v3 — the label table is fully mapped; only the timer block remains):
+// - 0x009F + 0x00DF: contiguous coverage of 0x009F-0x011E. The v2 scan started at 0x00DF
+//   and missed the 3-byte blind spot 0x00DC-0x00DE, only reachable through the tail of the
+//   0x009F zone-config read — a differential capture (P1 exit 30s->25s) changed nothing in
+//   0x00DF+, placing P1 exit exactly in that blind spot. Working layout hypothesis:
+//   exit P1-P4 @ 0x00DC, entry P1-P4 @ 0x00E0, pre-alarm @ 0x00E4, then 05x4 and 0Ax4.
 bool BentelKyo::memory_scan_next_() {
   static const uint16_t SCAN_ADDRS[] = {
-      // label-table continuation past the code names
-      0x3600, 0x3640, 0x3680, 0x36C0, 0x3700, 0x3740, 0x3780, 0x37C0,
-      // area-timer block, for differential timer capture
-      0x00DF,
+      // zone-config block + timer region, contiguous (covers the 0x00DC-0x00DE blind spot)
+      0x009F, 0x00DF,
   };
   static const int SCAN_CHUNKS = sizeof(SCAN_ADDRS) / sizeof(SCAN_ADDRS[0]);
 

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1147,11 +1147,41 @@ bool BentelKyo::read_zone_config_() {
   return false;
 }
 
+bool BentelKyo::is_kyo8_family_() const {
+  // KYO8W is intentionally excluded. Despite the "KYO8W"/"KYO8WG" firmware name it uses
+  // KYO32-format status/partition responses (issue #107, fixed by PR #109), and the runtime
+  // paths already route it through KYO32 (see the is_kyo8 checks at the partition command
+  // selection and parser). We have no KYO8W config-memory trace, so its name tables and fixed
+  // registers stay on the KYO32 (non-G) map — the pre-#113 behavior — rather than the KYO8
+  // 0x3250 map, until a KYO8W trace confirms its layout.
+  return this->alarm_model_ == AlarmModel::KYO_4 || this->alarm_model_ == AlarmModel::KYO_8 ||
+         this->alarm_model_ == AlarmModel::KYO_8G;
+}
+
+const uint16_t *BentelKyo::select_name_bases_(const uint16_t *nong, const uint16_t *kyo32g,
+                                              const uint16_t *kyo8) const {
+  if (this->alarm_model_ == AlarmModel::KYO_32G)
+    return kyo32g;
+  if (this->is_kyo8_family_())
+    return kyo8;
+  return nong;
+}
+
 // Reads one 64-byte block (up to 4 names) of a name table per call, advancing
 // config_chunk_index_. Returns true when the whole table has been read. Keeps each
 // update() cycle short (one serial transaction) instead of blocking on several.
 bool BentelKyo::read_name_table_chunk_(const uint16_t *bases, int num_blocks, int count,
                                        std::string *out, const char *what) {
+  if (bases == nullptr) {
+    // Address map not yet known for this model (issue #113) — skip rather than decode
+    // garbage from a wrong address. Names stay empty.
+    ESP_LOGW(TAG,
+             "%s names: address map unknown for firmware '%s' — skipped. Please open an issue at "
+             "https://github.com/lorenzo-deluca/espkyogate with a 'serial_trace' dump to map it.",
+             what, this->firmware_version_);
+    this->config_chunk_index_ = 0;
+    return true;
+  }
   int blk = this->config_chunk_index_;
   uint8_t rx[255];
   int rc = this->read_register_(bases[blk], 0x3F, rx, 300);
@@ -1180,8 +1210,11 @@ bool BentelKyo::read_zone_names_() {
   // zone names at 0x19B0-0x1BAF instead of 0x2E00-0x2FFF.
   static const uint16_t BASE_ADDRS_NONG[] = {0x2E00, 0x2E40, 0x2E80, 0x2EC0, 0x2F00, 0x2F40, 0x2F80, 0x2FC0};
   static const uint16_t BASE_ADDRS_32G[] = {0x19B0, 0x19F0, 0x1A30, 0x1A70, 0x1AB0, 0x1AF0, 0x1B30, 0x1B70};
-  const uint16_t *bases =
-      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_32G : BASE_ADDRS_NONG;
+  // KYO8 2.04 keeps the user-label table higher, starting at 0x3250 (issue #113):
+  // 8 zone names in two 64-byte blocks (0x3250-0x328F, 0x3290-0x32CF). Confirmed against
+  // the 0x009F zone-config block.
+  static const uint16_t BASE_ADDRS_KYO8[] = {0x3250, 0x3290};
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
   int num_blocks = (this->max_zones_ <= 8) ? 2 : 8;
   return this->read_name_table_chunk_(bases, num_blocks, this->max_zones_, this->zone_name_, "Zone");
 }
@@ -1238,8 +1271,9 @@ bool BentelKyo::read_output_names_() {
   // via an on-device memory scan (issue #93).
   static const uint16_t BASE_ADDRS_NONG[] = {0x3280, 0x32C0, 0x3300, 0x3340};
   static const uint16_t BASE_ADDRS_32G[] = {0x1E30, 0x1E70, 0x1EB0, 0x1EF0};
-  const uint16_t *bases =
-      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_32G : BASE_ADDRS_NONG;
+  // KYO8 output-name location not yet known (issue #113): the 0x3280 block holds the
+  // contiguous zone/partition/keypad label table, not outputs. Skip until located.
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_OUTPUTS, this->output_name_, "Output");
 }
 
@@ -1247,6 +1281,17 @@ void BentelKyo::read_partition_config_() {
   // Timers at 0x016F: 26 bytes total (section 10.5)
   // Bytes 0-15: entry/exit timers (2 bytes per partition: entry, exit) for 8 partitions
   // Bytes 16-23: siren duration (1 byte per partition)
+  if (this->is_kyo8_family_()) {
+    // On KYO8 2.04, 0x016F returns an index table (00 00 01 0X FF FF), not timers
+    // (issue #113). The real area timers live in/after the 0x009F block. Skip until
+    // decoded, leaving the timer values at their defaults. Logged once per config read
+    // (this function is not in the ~60s periodic republish, so it does not spam).
+    ESP_LOGW(TAG,
+             "Partition timers: register address unknown for firmware '%s' — skipped. Please open "
+             "an issue at https://github.com/lorenzo-deluca/espkyogate with a 'serial_trace' dump.",
+             this->firmware_version_);
+    return;
+  }
   uint8_t rx[255];
   int count = this->read_register_(0x016F, 0x1A, rx, 300);
   if (count < 6 + 26) {
@@ -1310,8 +1355,9 @@ bool BentelKyo::read_keyfob_names_() {
   // at 0x1D30-0x1E2F instead of 0x3180-0x327F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3180, 0x31C0, 0x3200, 0x3240};
   static const uint16_t BASE_ADDRS_32G[] = {0x1D30, 0x1D70, 0x1DB0, 0x1DF0};
-  const uint16_t *bases =
-      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_32G : BASE_ADDRS_NONG;
+  // KYO8 keyfob-name location not yet known (issue #113): 0x3180-0x324F reads the LCD
+  // menu-string ROM on this firmware. Skip until located.
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 4, KYO_MAX_KEYFOBS, this->keyfob_name_, "Keyfob");
 }
 
@@ -1321,9 +1367,16 @@ bool BentelKyo::read_partition_names_() {
   // at 0x1750-0x17CF instead of 0x2BA0-0x2C1F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x2BA0, 0x2BE0};
   static const uint16_t BASE_ADDRS_32G[] = {0x1750, 0x1790};
-  const uint16_t *bases =
-      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_32G : BASE_ADDRS_NONG;
-  return this->read_name_table_chunk_(bases, 2, KYO_MAX_PARTITIONS, this->partition_name_, "Partition");
+  // KYO8 2.04: the area names sit at 0x32D0 (PERIMETRO, VOLUMETRICI, Area 03, Area 04),
+  // right after the 8 zone names (issue #113). KYO4/8 have 4 partitions (see the
+  // ranges_kyo8 table in decode_event_code_), so a single 64-byte block covers them;
+  // 0x3310+ holds keypad labels, which is why only 4 slots are read.
+  static const uint16_t BASE_ADDRS_KYO8[] = {0x32D0};
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
+  bool kyo8 = this->is_kyo8_family_();
+  int num_blocks = kyo8 ? 1 : 2;
+  int count = kyo8 ? KYO_PARTITIONS_8 : KYO_MAX_PARTITIONS;
+  return this->read_name_table_chunk_(bases, num_blocks, count, this->partition_name_, "Partition");
 }
 
 bool BentelKyo::read_code_names_() {
@@ -1332,12 +1385,20 @@ bool BentelKyo::read_code_names_() {
   // at 0x1BB0-0x1D2F instead of 0x3000-0x317F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x3000, 0x3040, 0x3080, 0x30C0, 0x3100, 0x3140};
   static const uint16_t BASE_ADDRS_32G[] = {0x1BB0, 0x1BF0, 0x1C30, 0x1C70, 0x1CB0, 0x1CF0};
-  const uint16_t *bases =
-      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_32G : BASE_ADDRS_NONG;
+  // KYO8 code-name location not yet known (issue #113): 0x3000-0x30BF reads binary config
+  // and 0x30C0+ the LCD menu-string ROM on this firmware. Skip until located.
+  const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, nullptr);
   return this->read_name_table_chunk_(bases, 6, KYO_MAX_CODES, this->code_name_, "Code");
 }
 
 void BentelKyo::read_panel_mode_() {
+  if (this->is_kyo8_family_()) {
+    // 0x01E6 is not the panel-mode register on KYO8 2.04 — it returns 00 00, which the
+    // {0x11,0x10} idle baseline reads as a permanent false programming=YES (issue #113).
+    // Leave panel_programming_mode_ at its idle default; the real state, if needed, is in
+    // the continuous F0 68 status poll.
+    return;
+  }
   uint8_t rx[255];
   int count = this->read_register_(0x01E6, 0x02, rx, 300);
   if (count < 6 + 2) {
@@ -1356,6 +1417,12 @@ void BentelKyo::read_panel_mode_() {
 }
 
 void BentelKyo::read_status_flags_() {
+  if (this->is_kyo8_family_()) {
+    // 0x1503 reads ASCII text, not trouble bit-flags, on KYO8 2.04, which the "any byte
+    // != 0xFF" rule reads as a permanent false trouble=YES (issue #113). Leave
+    // trouble_active_ at its no-trouble default until the real register is located.
+    return;
+  }
   uint8_t rx[255];
   int count = this->read_register_(0x1503, 0x05, rx, 300);
   if (count < 6 + 5) {
@@ -1589,17 +1656,22 @@ void BentelKyo::publish_text_sensors_() {
         if (idx >= KYO_MAX_KEYFOBS) continue;
         entry.sensor->publish_state(this->keyfob_name_[idx].empty() ? "N/A" : this->keyfob_name_[idx]);
         break;
+      // Partition timers come from 0x016F, which is unmapped on the KYO8 family (issue #113);
+      // publish "N/A" there instead of the default 0 so the value isn't mistaken for a real one.
       case TEXT_PARTITION_ENTRY_DELAY:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(to_string(this->partition_entry_delay_[idx]) + "s");
+        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
+                                                            : to_string(this->partition_entry_delay_[idx]) + "s");
         break;
       case TEXT_PARTITION_EXIT_DELAY:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(to_string(this->partition_exit_delay_[idx]) + "s");
+        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
+                                                            : to_string(this->partition_exit_delay_[idx]) + "s");
         break;
       case TEXT_PARTITION_SIREN_TIMER:
         if (idx >= KYO_MAX_PARTITIONS) continue;
-        entry.sensor->publish_state(to_string(this->partition_siren_timer_[idx]));
+        entry.sensor->publish_state(this->is_kyo8_family_() ? "N/A"
+                                                            : to_string(this->partition_siren_timer_[idx]));
         break;
       case TEXT_PARTITION_NAME:
         if (idx >= KYO_MAX_PARTITIONS) continue;

--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1128,12 +1128,11 @@ bool BentelKyo::read_zone_config_() {
     ESP_LOGW(TAG, "Zone config read at 0x%04X failed: got %d bytes", BASE_ADDRS[blk], count);
   } else {
     // KYO8 2.04 prefixes the block with a 4-byte header, so zone records start at 0x00A3
-    // instead of 0x009F (issue #113 validation: with the shift, zones 1-4 land in area 1
-    // and zones 5-6 in area 2, matching the panel's PERIMETRO/VOLUMETRICI assignment;
-    // without it zone 1 reads area 0x00 = "None").
+    // instead of 0x009F (issue #113 validation: with the shift, every zone lands in the
+    // area configured on the panel; without it zone 1 reads area 0x00 = "None").
     // KYO8 record bytes, cross-checked against the Bentel Security Suite zone page:
     // [0]=type, [1]=unknown (always 0x00, NOT a wireless-enrolled flag), [2]=area mask,
-    // [3]=alarm-cycle count "Cicli" (0-14; 0x0F = "Ripetitivo"/unlimited).
+    // [3]=alarm-cycle count (0-14; 0x0F = repetitive/unlimited).
     // The header also means only 15 full records fit in the 64 returned bytes — cap the
     // loop so a hypothetical >8-zone KYO8 read can never index past the buffer.
     bool kyo8 = this->is_kyo8_family_();
@@ -1310,16 +1309,16 @@ void BentelKyo::read_partition_config_() {
   if (this->is_kyo8_family_()) {
     // KYO8 2.04 keeps the area timers right after the zone-config block, not at 0x016F
     // (which returns an index table on this firmware). Layout pinned by differential
-    // captures and cross-checked against the Bentel Security Suite "Aree" page
-    // (issue #113); official field names:
-    //   0x00DC-0x00DF: "T. Uscita"  — exit delay P1-P4 (seconds)
-    //   0x00E0-0x00E3: "T. Ingresso" — entry delay P1-P4 (seconds)
-    //   0x00E4-0x00E7: "T. Preavviso" — scheduler advance-warning P1-P4 (minutes)
-    //   0x00E8-0x00EB: "T. And Zone" P1-P4 (15-second steps)
-    //   0x00EC-0x00EF: "T. Cod And" P1-P4 (seconds)
-    //   0x00F8:        "Tempo di Ronda" — patrol time (minutes)
-    //   0x00FA:        "Tempo di Allarme" — alarm-cycle/siren duration, global (minutes,
-    //                  0-63; 0 = siren outputs never fire)
+    // captures and cross-checked field by field against the Bentel Security Suite
+    // "Areas" page (issue #113; see PROTOCOL.md 9.2 for the original Suite UI names):
+    //   0x00DC-0x00DF: exit delay P1-P4 (seconds)
+    //   0x00E0-0x00E3: entry delay P1-P4 (seconds)
+    //   0x00E4-0x00E7: scheduler advance-warning time P1-P4 (minutes)
+    //   0x00E8-0x00EB: And-Zone time P1-P4 (15-second steps)
+    //   0x00EC-0x00EF: And-Code time P1-P4 (seconds)
+    //   0x00F8:        patrol time, global (minutes)
+    //   0x00FA:        alarm-cycle/siren duration, global (minutes, 0-63;
+    //                  0 = siren outputs never fire)
     uint8_t rx[255];
     int count = this->read_register_(0x00DC, 0x1F, rx, 300);
     if (count < 6 + 31) {
@@ -1422,10 +1421,10 @@ bool BentelKyo::read_partition_names_() {
   // at 0x1750-0x17CF instead of 0x2BA0-0x2C1F.
   static const uint16_t BASE_ADDRS_NONG[] = {0x2BA0, 0x2BE0};
   static const uint16_t BASE_ADDRS_32G[] = {0x1750, 0x1790};
-  // KYO8 2.04: the area names sit at 0x32D0 (PERIMETRO, VOLUMETRICI, Area 03, Area 04),
-  // right after the 8 zone names (issue #113). KYO4/8 have 4 partitions (see the
-  // ranges_kyo8 table in decode_event_code_), so a single 64-byte block covers them;
-  // 0x3310+ holds keypad labels, which is why only 4 slots are read.
+  // KYO8 2.04: the area names sit at 0x32D0, right after the 8 zone names (issue #113,
+  // confirmed against the panel keypad). KYO4/8 have 4 partitions (see the ranges_kyo8
+  // table in decode_event_code_), so a single 64-byte block covers them; 0x3310+ holds
+  // keypad labels, which is why only 4 slots are read.
   static const uint16_t BASE_ADDRS_KYO8[] = {0x32D0};
   const uint16_t *bases = this->select_name_bases_(BASE_ADDRS_NONG, BASE_ADDRS_32G, BASE_ADDRS_KYO8);
   bool kyo8 = this->is_kyo8_family_();

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -28,6 +28,7 @@ static const char *const TAG = "bentel_kyo";
 static const uint8_t KYO_MAX_ZONES = 32;
 static const uint8_t KYO_MAX_ZONES_8 = 8;
 static const uint8_t KYO_MAX_PARTITIONS = 8;
+static const uint8_t KYO_PARTITIONS_8 = 4;  // KYO4/8 expose 4 partitions (see decode_event_code_)
 static const uint8_t KYO_MAX_OUTPUTS = 16;
 static const uint8_t KYO_MAX_KEYFOBS = 16;
 static const uint8_t KYO_MAX_CODES = 24;
@@ -182,6 +183,16 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   void handle_serial_failure_();
   int send_message_(const uint8_t *cmd, int cmd_len, uint8_t *response, uint32_t timeout_ms = SERIAL_TIMEOUT_MS);
   int read_register_(uint16_t address, uint8_t length, uint8_t *response, uint32_t timeout_ms = SERIAL_TIMEOUT_MS);
+  // Model-family helper (issue #113): KYO4/8/8G use a config memory map distinct from both
+  // KYO32 (non-G) and KYO32G, so config-table addresses must branch three ways. KYO8W is
+  // excluded — it uses KYO32-format runtime responses (issue #107/PR #109) and has no
+  // validated KYO8 config trace; see the definition for details.
+  bool is_kyo8_family_() const;
+  // Selects the per-model base-address map for a config table. Returns nullptr when the
+  // table location is not yet known for the current model, so the reader skips it instead
+  // of decoding garbage from the wrong address.
+  const uint16_t *select_name_bases_(const uint16_t *nong, const uint16_t *kyo32g,
+                                     const uint16_t *kyo8) const;
   // Config reads are chunked: one 64-byte block per update() cycle, returning true
   // when the whole table is done, so a single cycle never blocks on multiple reads.
   bool read_zone_config_();

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -144,6 +144,7 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   void arm_preset(uint8_t total_mask, uint8_t partial_mask, uint8_t partial_d0_mask);
   void reset_alarms();
   void read_event_log();
+  void memory_scan();  // debug: dump unmapped config regions to the log (issue #113)
   void activate_output(uint8_t output_number);
   void deactivate_output(uint8_t output_number);
   void pulse_output(uint8_t output_number, uint32_t pulse_time_ms);
@@ -209,6 +210,7 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   bool read_name_table_chunk_(const uint16_t *bases, int num_blocks, int count,
                               std::string *out, const char *what);
   bool read_event_log_next_();  // reads one 64-byte chunk per call, returns true when done
+  bool memory_scan_next_();     // reads one 64-byte chunk per call, returns true when done
   const char *decode_event_code_(uint16_t code, uint8_t *entity_out, char *buf, size_t buf_len);
   void read_panel_mode_();
   void read_status_flags_();
@@ -345,6 +347,10 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
   bool event_log_read_pending_{false};
   int event_log_chunk_index_{0};
   int event_log_entries_logged_{0};
+
+  // Debug memory scan (on-demand via button, issue #113)
+  bool memory_scan_pending_{false};
+  int memory_scan_chunk_index_{0};
 };
 
 }  // namespace bentel_kyo

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -30,6 +30,7 @@ static const uint8_t KYO_MAX_ZONES_8 = 8;
 static const uint8_t KYO_MAX_PARTITIONS = 8;
 static const uint8_t KYO_PARTITIONS_8 = 4;  // KYO4/8 expose 4 partitions (see decode_event_code_)
 static const uint8_t KYO_MAX_OUTPUTS = 16;
+static const uint8_t KYO_OUTPUTS_8 = 5;  // KYO4/8 expose 5 outputs (status bits 0-4)
 static const uint8_t KYO_MAX_KEYFOBS = 16;
 static const uint8_t KYO_MAX_CODES = 24;
 

--- a/components/bentel_kyo/button.h
+++ b/components/bentel_kyo/button.h
@@ -50,6 +50,18 @@ class BentelKyoReadEventLogButton : public button::Button, public Component {
   BentelKyo *parent_{nullptr};
 };
 
+class BentelKyoMemoryScanButton : public button::Button, public Component {
+ public:
+  void set_parent(BentelKyo *parent) { this->parent_ = parent; }
+
+  void press_action() override {
+    this->parent_->memory_scan();
+  }
+
+ protected:
+  BentelKyo *parent_{nullptr};
+};
+
 class BentelKyoArmAllButton : public button::Button, public Component {
  public:
   void set_parent(BentelKyo *parent) { this->parent_ = parent; }

--- a/components/bentel_kyo/button.py
+++ b/components/bentel_kyo/button.py
@@ -31,6 +31,10 @@ BentelKyoReadEventLogButton = bentel_kyo_ns.class_(
     "BentelKyoReadEventLogButton", button.Button, cg.Component
 )
 
+BentelKyoMemoryScanButton = bentel_kyo_ns.class_(
+    "BentelKyoMemoryScanButton", button.Button, cg.Component
+)
+
 BentelKyoActivateOutputButton = bentel_kyo_ns.class_(
     "BentelKyoActivateOutputButton", button.Button, cg.Component
 )
@@ -70,6 +74,7 @@ BUTTON_TYPES = {
     "arm_preset": (BentelKyoArmPresetButton, "mdi:shield-account", None),
     "reset_alarms": (BentelKyoResetAlarmsButton, "mdi:bell-cancel", None),
     "read_event_log": (BentelKyoReadEventLogButton, "mdi:history", ENTITY_CATEGORY_CONFIG),
+    "memory_scan": (BentelKyoMemoryScanButton, "mdi:magnify-scan", ENTITY_CATEGORY_CONFIG),
     "activate_output": (BentelKyoActivateOutputButton, "mdi:electric-switch", None),
     "deactivate_output": (BentelKyoDeactivateOutputButton, "mdi:electric-switch-closed", None),
     "pulse_output": (BentelKyoPulseOutputButton, "mdi:pulse", None),

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -734,8 +734,19 @@ Other KYO8 2.04 findings from the same scan:
 - The KYO32 fixed registers do not apply: `0x01E6` (panel mode) reads `00 00`,
   `0x1503` (status flags) reads ASCII text, `0x016F` (partition timers) reads a
   6-byte-record index table, and `0x01DF`-`0x021E` is all zeros.
-- The area timers (`Tempi -> Aree`) live around `0x00DC`-`0x00EF`, immediately
-  after the zone-config block; the per-field layout is not yet decoded.
+- The area timers (`Tempi -> Aree`) live at `0x00DC`, immediately after the
+  zone-config block. Layout confirmed by differential capture (changing P1 exit
+  30s -> 25s flipped exactly `0x00DC` from `1E` to `19`):
+
+  | Address | Field | Unit |
+  |---------|-------|------|
+  | `0x00DC`-`0x00DF` | Exit delay, partitions 1-4 | seconds |
+  | `0x00E0`-`0x00E3` | Entry delay, partitions 1-4 | seconds |
+  | `0x00E4`-`0x00E7` | Pre-alarm time, partitions 1-4 | minutes |
+  | `0x00E8`-`0x00EB` | Unconfirmed (matches configured anti-zone count) | — |
+  | `0x00EC`-`0x00EF` | Unconfirmed (matches configured anti-code time) | seconds |
+
+  The siren-duration byte has not been identified yet.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -805,6 +805,29 @@ Other KYO8 2.04 findings from the same scan:
   and write the full panel configuration with no B-Mod cable, enabling
   Suite-vs-memory-scan differentials for any register.
 
+### 9.3 KYO8 2.04 memory map (full-sweep reference)
+
+A full sweep of the readable address ranges on a KYO8 2.04 (same range set used
+for the KYO32G, ~1 minute with normal polling still running) surfaced these
+regions beyond the ones mapped above:
+
+| Range | Content |
+|-------|---------|
+| `0x0000`-`0x003F` | **Not readable** — the panel answers the `0xF0` read with a short 19-byte reply instead of a full response. The same window reads normally on KYO32G 2.13 |
+| `0x0040`-`0x00A2` | 9-byte records with `0x0F` at offset 0, back-to-back (11 slots; the last one overlaps the 4-byte zone-config header at `0x009F`) — plausibly per-code config records; unmapped |
+| `0x08BB`-`0x09FF` | Sequential 3-byte slot table, first byte an index incrementing `0x01`, `0x02`, … (past `0x6B` where the sweep window ends); purpose unknown |
+| `0x1490`-`0x15FF` (approx.) | Second copy of the code names (`Codice 4` observed at `0x14C0`, implying `Codice 1` at `0x1490`) — distinct from the `0x3490` table the component reads; which copy the keypad uses is unknown |
+| `0x2BA0`-`~0x2E05` | Event log — timestamped records (`DD MM YY HH mm` + event code) matching the keypad's `Registro Eventi`. Note this address is the partition-name table on KYO32 non-G (section 10.10) and string ROM on KYO32G (section 10.28) |
+| `0x2E60`-`0x2E8F` | Misc telephony/config bytes, including an access PIN stored as plain ASCII around `0x2E76` |
+| `0x2E90`-`0x2EA6` | DTMF/keypad character table (`, * # ABCDEF`) |
+| `0x2EA7`-`0x30BB` | Dense binary tables, unmapped |
+| `0x30C0`-`0x381F` | LCD menu strings followed by the user-label tables of section 9.2 |
+
+**Privacy note for scan logs:** a KYO8 sweep captures personal data — event-log
+timestamps, code and phone-book names, an ASCII PIN near `0x2E76` and BCD phone
+digits near `0x0109`. Redact these regions before attaching scan output to a
+public issue.
+
 ---
 
 ## 10. Configuration Register Map

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -745,8 +745,19 @@ Other KYO8 2.04 findings from the same scan:
   | `0x00E4`-`0x00E7` | Pre-alarm time, partitions 1-4 | minutes |
   | `0x00E8`-`0x00EB` | Unconfirmed (matches configured anti-zone count) | — |
   | `0x00EC`-`0x00EF` | Unconfirmed (matches configured anti-code time) | seconds |
+  | `0x00FA` | Siren duration, single global byte (differential: 3min -> 2min flipped only this byte; `0x00F9` may be a related alarm time) | minutes |
 
-  The siren-duration byte has not been identified yet.
+- The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
+  records begin at `0x00A3` (validated: with the shift, zones land in the areas
+  configured on the panel; without it zone 1 reads area `0x00`).
+- The `0xC045`/`0xC0B1` ESN windows read unrelated config data on KYO8 — a panel
+  with no wireless receiver and zero keyfobs returned non-empty "serials", with
+  area-timer bytes visible in the higher slots. The wireless-enrollment storage,
+  if this hardware variant has one, has not been located.
+- Entering the installer menu on the keypad makes the panel stop answering the
+  serial bus entirely (polls time out until the menu is exited), so programming
+  mode cannot be detected via a register read on this firmware — the
+  communication-status sensor is the only observable signal.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -734,29 +734,33 @@ Other KYO8 2.04 findings from the same scan:
 - The KYO32 fixed registers do not apply: `0x01E6` (panel mode) reads `00 00`,
   `0x1503` (status flags) reads ASCII text, `0x016F` (partition timers) reads a
   6-byte-record index table, and `0x01DF`-`0x021E` is all zeros.
-- The area timers (`Tempi -> Aree`) live at `0x00DC`, immediately after the
-  zone-config block. Layout pinned by differential captures (single-byte flips
-  for exit delay, siren duration and patrol time) and cross-checked field by
-  field against the Bentel Security Suite 5.5.4 "Aree" page:
+- The area timers (the keypad's Times -> Areas menu, `Tempi -> Aree`) live at
+  `0x00DC`, immediately after the zone-config block. Layout pinned by
+  differential captures (single-byte flips for exit delay, siren duration and
+  patrol time) and cross-checked field by field against the Bentel Security
+  Suite 5.5.4 "Areas" page:
 
-  | Address | Suite field | Unit |
-  |---------|-------------|------|
-  | `0x00DC`-`0x00DF` | T. Uscita (exit delay), partitions 1-4 | seconds |
-  | `0x00E0`-`0x00E3` | T. Ingresso (entry delay), partitions 1-4 | seconds |
-  | `0x00E4`-`0x00E7` | T. Preavviso (scheduler advance warning), partitions 1-4 | minutes |
-  | `0x00E8`-`0x00EB` | T. And Zone, partitions 1-4 | 15-second steps |
-  | `0x00EC`-`0x00EF` | T. Cod And, partitions 1-4 | seconds |
-  | `0x00F8` | Tempo di Ronda (patrol time) | minutes |
-  | `0x00FA` | Tempo di Allarme (alarm-cycle/siren duration, 0-63; 0 = siren outputs never fire) | minutes |
+  | Address | Field | Unit |
+  |---------|-------|------|
+  | `0x00DC`-`0x00DF` | Exit delay, partitions 1-4 | seconds |
+  | `0x00E0`-`0x00E3` | Entry delay, partitions 1-4 | seconds |
+  | `0x00E4`-`0x00E7` | Scheduler advance-warning time, partitions 1-4 | minutes |
+  | `0x00E8`-`0x00EB` | And-Zone time, partitions 1-4 | 15-second steps |
+  | `0x00EC`-`0x00EF` | And-Code time, partitions 1-4 | seconds |
+  | `0x00F8` | Patrol time (global) | minutes |
+  | `0x00FA` | Alarm-cycle/siren duration (global, 0-63; 0 = siren outputs never fire) | minutes |
 
-  Still unidentified: `0x00F0`-`0x00F7` (`1E` x8) and `0x00F9`.
+  Original labels in the (Italian-only) Suite UI, top to bottom: `T. Uscita`,
+  `T. Ingresso`, `T. Preavviso`, `T. And Zone`, `T. Cod And`, `Tempo di Ronda`,
+  `Tempo di Allarme`. Still unidentified: `0x00F0`-`0x00F7` (`1E` x8) and
+  `0x00F9`.
 
 - The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
   records begin at `0x00A3` (validated: with the shift, zones land in the areas
   configured on the panel; without it zone 1 reads area `0x00`). Record layout,
   cross-checked against the Suite zone page: byte 0 = type, byte 1 = unknown
   (always `0x00`, not a wireless-enrolled flag), byte 2 = area mask, byte 3 =
-  alarm-cycle count "Cicli" (0-14; `0x0F` = "Ripetitivo"/unlimited).
+  alarm-cycle count (0-14; `0x0F` = repetitive/unlimited; `Cicli` in the Suite).
 - The `0xC045`/`0xC0B1` ESN windows read unrelated config data on KYO8 — a panel
   with no wireless receiver and zero keyfobs returned non-empty "serials", with
   area-timer bytes visible in the higher slots. The wireless-enrollment storage,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -766,11 +766,14 @@ Other KYO8 2.04 findings from the same scan:
   exposes 3: outputs 1-2 = 30s/30s, output 3 = 3s/3s, slots 4-5 at defaults).
 
   The last unidentified run, `0x00F0`-`0x00F7` (`1E` x8), matches no Suite
-  field on KYO8. Given the block layout (partition 1-4 timers immediately
-  before), the likely explanation is exit + entry delay slots for partitions
-  5-8 — present in the bigger KYO models' map, unused at their default (30s)
-  on KYO8, and not testable there since the KYO8 UI only exposes 4 areas. A
-  differential capture on a KYO32 could confirm.
+  field on KYO8. An earlier guess (exit/entry slots for partitions 5-8) was
+  **ruled out** by a full config scan of a KYO32G 2.13 (section 10.28): that
+  model stores all eight areas' timers together at `0x016F` (areas 5-8
+  included), and its 32-zone config table fills `0x009F`-`0x011E`, so on the
+  KYO32 family `0x00F0`-`0x00F7` is zone-config data, not timers. The KYO8
+  compact timer block is therefore its own layout; these 8 bytes are most
+  likely two further per-area (1-4) timer types at their 30s default, still
+  unmapped for lack of a Suite field to flip.
 
 - The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
   records begin at `0x00A3` (validated: with the shift, zones land in the areas

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -704,6 +704,39 @@ are not a single uniform offset from the non-G map, so each table is mapped
 individually. The component selects these addresses when the detected model is
 KYO32G (see `read_*_names_()` in `bentel_kyo.cpp`).
 
+### 9.2 KYO8 name table layout (firmware 2.04)
+
+The KYO4/8/8G family uses a third, distinct label-table layout, mapped via an
+on-device memory scan on a KYO8 2.04 (issue #113). The non-G addresses respond
+but land on the LCD menu-string ROM (`0x30C0`-`0x324F`) or unrelated data. The
+user-label table is one contiguous block at `0x3250`-`0x37EF`, in a different
+entity order than the non-G map:
+
+| Table | KYO8 base | Count | Default labels |
+|-------|-----------|-------|----------------|
+| Zone names | `0x3250` | 8 | `Zona N` |
+| Partition (area) names | `0x32D0` | 4 | `Area 0N` |
+| Keypad names | `0x3310` | 8 | `Tastiera 0N` |
+| Reader names | `0x3390` | 16 | `Lettore NN` |
+| Code names | `0x3490` | 24 | `Codice N` |
+| Keyfob (digital key) names | `0x3610` | 16 | `Attivatore N` |
+| Output names | `0x3710` | 5 | `Uscita N` |
+| Phone number names | `0x3760` | 8 | `Numero N` |
+
+The table ends with a single generic `Chiave` slot at `0x37E0` followed by ROM
+date-format strings (`GMA`/`MGA`/`AMG`). Entity counts follow the KYO8 hardware
+(4 partitions, 5 outputs); "attivatore" is Bentel's term for the digital keys
+presented to readers, matching the non-G "digital key names" table by relative
+position and count.
+
+Other KYO8 2.04 findings from the same scan:
+
+- The KYO32 fixed registers do not apply: `0x01E6` (panel mode) reads `00 00`,
+  `0x1503` (status flags) reads ASCII text, `0x016F` (partition timers) reads a
+  6-byte-record index table, and `0x01DF`-`0x021E` is all zeros.
+- The area timers (`Tempi -> Aree`) live around `0x00DC`-`0x00EF`, immediately
+  after the zone-config block; the per-field layout is not yet decoded.
+
 ---
 
 ## 10. Configuration Register Map

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -748,12 +748,29 @@ Other KYO8 2.04 findings from the same scan:
   | `0x00E8`-`0x00EB` | And-Zone time, partitions 1-4 | 15-second steps |
   | `0x00EC`-`0x00EF` | And-Code time, partitions 1-4 | seconds |
   | `0x00F8` | Patrol time (global) | minutes |
+  | `0x00F9` | Handsfree/speakerphone timeout (global) | — |
   | `0x00FA` | Alarm-cycle/siren duration (global, 0-63; 0 = siren outputs never fire) | minutes |
+  | `0x00FF`-`0x0103` | Output monostable ON time, outputs 1-5 | seconds |
+  | `0x0104`-`0x0108` | Output monostable OFF time, outputs 1-5 | seconds |
+  | `0x0112` | Dial attempts | count |
+  | `0x0119` | Remote-assistance ring count | count |
 
-  Original labels in the (Italian-only) Suite UI, top to bottom: `T. Uscita`,
-  `T. Ingresso`, `T. Preavviso`, `T. And Zone`, `T. Cod And`, `Tempo di Ronda`,
-  `Tempo di Allarme`. Still unidentified: `0x00F0`-`0x00F7` (`1E` x8) and
-  `0x00F9`.
+  Original labels in the (Italian-only) Suite UI: `T. Uscita`, `T. Ingresso`,
+  `T. Preavviso`, `T. And Zone`, `T. Cod And`, `Tempo di Ronda`,
+  `Timeout Vivavoce`, `Tempo di Allarme`, `N. Squilli Teleassistenza`. The
+  telephony fields were pinned by a batched differential (two fields changed
+  with distinct values, one scan): handsfree timeout 3→5 flipped `0x00F9`,
+  ring count 3→4 flipped `0x0119`; `0x0112` matches the configured dial
+  attempts, and the repeating `1E 1E 03 03 03` pattern at `0x00FF`-`0x0108`
+  matches the outputs' monostable ON/OFF times (5 slots, the KYO8 panel
+  exposes 3: outputs 1-2 = 30s/30s, output 3 = 3s/3s, slots 4-5 at defaults).
+
+  The last unidentified run, `0x00F0`-`0x00F7` (`1E` x8), matches no Suite
+  field on KYO8. Given the block layout (partition 1-4 timers immediately
+  before), the likely explanation is exit + entry delay slots for partitions
+  5-8 — present in the bigger KYO models' map, unused at their default (30s)
+  on KYO8, and not testable there since the KYO8 UI only exposes 4 areas. A
+  differential capture on a KYO32 could confirm.
 
 - The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
   records begin at `0x00A3` (validated: with the shift, zones land in the areas

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -735,21 +735,28 @@ Other KYO8 2.04 findings from the same scan:
   `0x1503` (status flags) reads ASCII text, `0x016F` (partition timers) reads a
   6-byte-record index table, and `0x01DF`-`0x021E` is all zeros.
 - The area timers (`Tempi -> Aree`) live at `0x00DC`, immediately after the
-  zone-config block. Layout confirmed by differential capture (changing P1 exit
-  30s -> 25s flipped exactly `0x00DC` from `1E` to `19`):
+  zone-config block. Layout pinned by differential captures (single-byte flips
+  for exit delay, siren duration and patrol time) and cross-checked field by
+  field against the Bentel Security Suite 5.5.4 "Aree" page:
 
-  | Address | Field | Unit |
-  |---------|-------|------|
-  | `0x00DC`-`0x00DF` | Exit delay, partitions 1-4 | seconds |
-  | `0x00E0`-`0x00E3` | Entry delay, partitions 1-4 | seconds |
-  | `0x00E4`-`0x00E7` | Pre-alarm time, partitions 1-4 | minutes |
-  | `0x00E8`-`0x00EB` | Unconfirmed (matches configured anti-zone count) | — |
-  | `0x00EC`-`0x00EF` | Unconfirmed (matches configured anti-code time) | seconds |
-  | `0x00FA` | Siren duration, single global byte (differential: 3min -> 2min flipped only this byte; `0x00F9` may be a related alarm time) | minutes |
+  | Address | Suite field | Unit |
+  |---------|-------------|------|
+  | `0x00DC`-`0x00DF` | T. Uscita (exit delay), partitions 1-4 | seconds |
+  | `0x00E0`-`0x00E3` | T. Ingresso (entry delay), partitions 1-4 | seconds |
+  | `0x00E4`-`0x00E7` | T. Preavviso (scheduler advance warning), partitions 1-4 | minutes |
+  | `0x00E8`-`0x00EB` | T. And Zone, partitions 1-4 | 15-second steps |
+  | `0x00EC`-`0x00EF` | T. Cod And, partitions 1-4 | seconds |
+  | `0x00F8` | Tempo di Ronda (patrol time) | minutes |
+  | `0x00FA` | Tempo di Allarme (alarm-cycle/siren duration, 0-63; 0 = siren outputs never fire) | minutes |
+
+  Still unidentified: `0x00F0`-`0x00F7` (`1E` x8) and `0x00F9`.
 
 - The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
   records begin at `0x00A3` (validated: with the shift, zones land in the areas
-  configured on the panel; without it zone 1 reads area `0x00`).
+  configured on the panel; without it zone 1 reads area `0x00`). Record layout,
+  cross-checked against the Suite zone page: byte 0 = type, byte 1 = unknown
+  (always `0x00`, not a wireless-enrolled flag), byte 2 = area mask, byte 3 =
+  alarm-cycle count "Cicli" (0-14; `0x0F` = "Ripetitivo"/unlimited).
 - The `0xC045`/`0xC0B1` ESN windows read unrelated config data on KYO8 — a panel
   with no wireless receiver and zero keyfobs returned non-empty "serials", with
   area-timer bytes visible in the higher slots. The wireless-enrollment storage,
@@ -758,6 +765,13 @@ Other KYO8 2.04 findings from the same scan:
   serial bus entirely (polls time out until the menu is exited), so programming
   mode cannot be detected via a register read on this firmware — the
   communication-status sensor is the only observable signal.
+- Verification technique: the official Bentel Security Suite can be run against
+  the panel *through* the ESP32 using a TCP-serial passthrough (e.g. the
+  esphome-stream-server external component with the UART left untouched while no
+  TCP client is connected), disabling this component's polling switch for the
+  session. A virtual COM port mapped to the ESP32's TCP port lets the Suite read
+  and write the full panel configuration with no B-Mod cable, enabling
+  Suite-vs-memory-scan differentials for any register.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -767,9 +767,9 @@ Other KYO8 2.04 findings from the same scan:
 
   The last unidentified run, `0x00F0`-`0x00F7` (`1E` x8), matches no Suite
   field on KYO8. An earlier guess (exit/entry slots for partitions 5-8) was
-  **ruled out** by a full config scan of a KYO32G 2.13 (section 10.28): that
-  model stores all eight areas' timers together at `0x016F` (areas 5-8
-  included), and its 32-zone config table fills `0x009F`-`0x011E`, so on the
+  **ruled out** by a full config scan of a KYO32G 2.13: that model stores all
+  eight areas' timers together at `0x016F` (areas 5-8 included, read and
+  correct), and its 32-zone config table fills `0x009F`-`0x011E`, so on the
   KYO32 family `0x00F0`-`0x00F7` is zone-config data, not timers. The KYO8
   compact timer block is therefore its own layout; these 8 bytes are most
   likely two further per-area (1-4) timer types at their 30s default, still

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -758,9 +758,17 @@ Other KYO8 2.04 findings from the same scan:
 - The zone-config block at `0x009F` starts with a 4-byte header on KYO8: zone
   records begin at `0x00A3` (validated: with the shift, zones land in the areas
   configured on the panel; without it zone 1 reads area `0x00`). Record layout,
-  cross-checked against the Suite zone page: byte 0 = type, byte 1 = unknown
-  (always `0x00`, not a wireless-enrolled flag), byte 2 = area mask, byte 3 =
-  alarm-cycle count (0-14; `0x0F` = repetitive/unlimited; `Cicli` in the Suite).
+  confirmed by Suite-vs-scan differentials:
+
+  | Offset | Field | Values |
+  |--------|-------|--------|
+  | +0 | Type + balance | Low bits: `0x00` Instant, `0x01` Delayed, `0x02` Path. High bits: wiring/balance, Normally Closed = `0x00`, Normally Open = `+0x08` (differential: NO→NC flipped `08`→`00`) |
+  | +1 | Attribute bitmask | Internal (`Interna`) = `0x20` (differential: toggling it flipped `00`→`20`); `0x00` = no attributes set. Previously suspected to be an enrolled flag — it is not |
+  | +2 | Area mask | `0x01` = area 1 … `0x08` = area 4 |
+  | +3 | Alarm cycles | 0-14; `0x0F` = repetitive/unlimited (`Cicli` in the Suite) |
+
+  Note the layout differs from KYO32 (section 10.1), where +1 is the
+  wireless-enrolled flag and +3 is the attribute byte.
 - The `0xC045`/`0xC0B1` ESN windows read unrelated config data on KYO8 — a panel
   with no wireless receiver and zero keyfobs returned non-empty "serials", with
   area-timer bytes visible in the higher slots. The wireless-enrollment storage,

--- a/espkyogate_configuration.yaml
+++ b/espkyogate_configuration.yaml
@@ -336,6 +336,12 @@ button:
     bentel_kyo_id: kyo
     type: read_event_log
     name: "Read Event Log"
+  # Debug: dumps unmapped config regions to the log (issue #113) — press once and
+  # attach the "SCAN 0x...." log lines to the issue
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: memory_scan
+    name: "Memory Scan (Debug)"
 
   # Datetime sync — sends current NTP time to the alarm panel
   - platform: bentel_kyo

--- a/tests/test_full.yaml
+++ b/tests/test_full.yaml
@@ -202,6 +202,10 @@ button:
     bentel_kyo_id: kyo
     type: read_event_log
     name: "Read Event Log"
+  - platform: bentel_kyo
+    bentel_kyo_id: kyo
+    type: memory_scan
+    name: "Memory Scan"
 
   # Arming
   - platform: bentel_kyo


### PR DESCRIPTION
## What

Adds a `memory_scan` debug button that dumps the panel's configuration address space to the ESPHome log as hex+ASCII `SCAN` lines — the tool behind the register mapping in #113 / #115 and the KYO32G map in #116.

- Read-only: it only issues the same `0xF0` read command used for normal configuration reads; nothing is ever written to the panel.
- Non-blocking: one 64-byte chunk per `update()` cycle (92 chunks, ~1 minute at the default 500ms polling). Status polling keeps running between chunks, so the panel stays reachable and HA entities keep updating throughout.
- Sweep ranges: `0x0000`-`0x09FF` (core config), `0x14C0`-`0x153F` (status/name region), `0x2BA0`-`0x381F` (name tables / string ROM).
- Failed chunks are logged as warnings and skipped (on KYO8 the `0x0000` window is not readable — expected); the scan always runs to completion.
- The log warns at scan start and end that the dump contains personal data (event log, code/phone-book names, access PINs) and must be redacted before being attached to a public issue.

## Usage

```yaml
button:
  - platform: bentel_kyo
    bentel_kyo_id: kyo
    type: memory_scan
    name: "Memory Scan (Debug)"
```

To try it before it ships in a release, point `external_components` at this branch:

```yaml
external_components:
  - source:
      type: git
      url: https://github.com/brembygit/espkyogate
      ref: debug/kyo8-memory-scan
    components: [bentel_kyo]
    refresh: 0s
```

Press the button once with the panel idle and copy the `SCAN 0x....` lines from the log. Typical workflow: take a baseline dump, change one panel setting, dump again, and diff — the flipped byte is the register. README gains a "Memory Scan (debug)" section documenting all of this.

## Validation

Field-tested on both families:

- **KYO8 2.04**: full 92-chunk sweep in ~46s with the panel link up throughout (status polling kept publishing, comm OK after). Produced the zone-record semantics, area-timer block and telephony registers of #115, plus the KYO8 memory map in PROTOCOL.md §9.3.
- **KYO32G 2.13**: full sweep used to build the complete configuration map (PROTOCOL.md §10.28) and to pinpoint the two mismapped registers fixed in #116.

Compile-tested with ESP-IDF (esp32dev), `tests/test_full.yaml` covers the button.

**Stacked on #115** (branched from it) — the diff shows those commits until #115 merges; the scan-specific changes are the last four commits (button plumbing, sweep, privacy warning, README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
