### PR TITLE
fix(KYO32): restore non-G partition-status register 0x14EC (#118)

### DIFF
--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -17,6 +17,7 @@ namespace bentel_kyo {
 // Static constexpr definitions
 constexpr uint8_t BentelKyo::CMD_GET_SENSOR_STATUS[];
 constexpr uint8_t BentelKyo::CMD_GET_PARTITION_KYO32[];
+constexpr uint8_t BentelKyo::CMD_GET_PARTITION_KYO32G[];
 constexpr uint8_t BentelKyo::CMD_GET_PARTITION_KYO8[];
 constexpr uint8_t BentelKyo::CMD_GET_VERSION[];
 constexpr uint8_t BentelKyo::CMD_RESET_ALARMS[];
@@ -148,9 +149,15 @@ void BentelKyo::loop() {
         if (this->alarm_model_ == AlarmModel::KYO_8 || this->alarm_model_ == AlarmModel::KYO_4 ||
             this->alarm_model_ == AlarmModel::KYO_8G) {
           cmd = CMD_GET_PARTITION_KYO8; cmd_len = sizeof(CMD_GET_PARTITION_KYO8);
-        } else {
-          // KYO32 and KYO32G use the same partition status command
+        } else if (this->alarm_model_ == AlarmModel::KYO_32) {
+          // KYO32 non-G reads partition status at 0x14EC. Using the KYO32G 0x1502
+          // register here returns FF padding, which the parser reads as all-disarmed
+          // (issue #118, regression from unifying the two commands). KYO8W is NOT in
+          // this branch: it was hardware-confirmed on the 0x1502 register in #109.
           cmd = CMD_GET_PARTITION_KYO32; cmd_len = sizeof(CMD_GET_PARTITION_KYO32);
+        } else {
+          // KYO32G and KYO8W both read partition status at 0x1502.
+          cmd = CMD_GET_PARTITION_KYO32G; cmd_len = sizeof(CMD_GET_PARTITION_KYO32G);
         }
         this->send_command_async_(cmd, cmd_len, 2);
         return;  // Don't update health yet — wait for partition response

--- a/components/bentel_kyo/bentel_kyo.h
+++ b/components/bentel_kyo/bentel_kyo.h
@@ -172,7 +172,10 @@ class BentelKyo : public PollingComponent, public uart::UARTDevice {
  protected:
   // Protocol commands
   static constexpr uint8_t CMD_GET_SENSOR_STATUS[6] = {0xF0, 0x04, 0xF0, 0x0A, 0x00, 0xEE};
-  static constexpr uint8_t CMD_GET_PARTITION_KYO32[6] = {0xF0, 0x02, 0x15, 0x12, 0x00, 0x19};
+  // Partition status lives at a different register per firmware generation:
+  // KYO32 non-G reads 0x14EC, while KYO32G (and KYO8W, per #109) read 0x1502.
+  static constexpr uint8_t CMD_GET_PARTITION_KYO32[6] = {0xF0, 0xEC, 0x14, 0x12, 0x00, 0x02};
+  static constexpr uint8_t CMD_GET_PARTITION_KYO32G[6] = {0xF0, 0x02, 0x15, 0x12, 0x00, 0x19};
   static constexpr uint8_t CMD_GET_PARTITION_KYO8[6] = {0xF0, 0x68, 0x0E, 0x09, 0x00, 0x6F};
   static constexpr uint8_t CMD_GET_VERSION[6] = {0xF0, 0x00, 0x00, 0x0B, 0x00, 0xFB};
   static constexpr uint8_t CMD_RESET_ALARMS[9] = {0x0F, 0x05, 0xF0, 0x01, 0x00, 0x05, 0xFF, 0x00, 0xFF};

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -351,12 +351,19 @@ bypassed zones, alarm memory, and tamper memory.
 
 | Model | Address | Command bytes |
 |-------|---------|---------------|
-| KYO32G | `0x1502` | `F0 02 15 12 00 19` |
+| KYO32G / KYO8W | `0x1502` | `F0 02 15 12 00 19` |
 | KYO32 (non-G) | `0x14EC` | `F0 EC 14 12 00 02` |
-| KYO8/4/8G/8W | `0x0E68` | `F0 68 0E 09 00 6F` |
+| KYO8/4/8G | `0x0E68` | `F0 68 0E 09 00 6F` |
 
-Read length byte: `0x12` (19 data bytes) for KYO32-series,
-`0x09` (10 data bytes) for KYO8-series.
+Read length byte: `0x12` (19 data bytes) for the KYO32-series responders
+(KYO32, KYO32G, KYO8W), `0x09` (10 data bytes) for KYO8/4/8G.
+
+Note: despite its 8-zone hardware, the wireless **KYO8W** answers with the
+KYO32-format response and reads partition status at the *KYO32G* register
+`0x1502`, not the non-G `0x14EC` — hardware-confirmed in #109. The KYO32
+non-G register was briefly shared with the G (`0x1502`) after the two commands
+were unified, which left non-G panels stuck reporting all partitions disarmed
+(#118); the addresses are model-specific and must not be merged again.
 
 #### KYO32/32G Response (26 bytes total)
 


### PR DESCRIPTION
Fixes #118.

## Problem

On **KYO32 non-G** panels every partition entity stays `DISARMED` even when the panel is physically armed. Arm commands are accepted and the alarm arms, but Home Assistant never reflects it.

## Root cause

The KYO32 and KYO32G partition-status commands were later unified onto a single register, `0x1502` (the KYO32G register), and used for both models. On a KYO32 non-G that address returns `FF` padding instead of partition data:

```
TX: F0 02 15 12 00 19          (0x1502, KYO32G register)
RX: F0 02 15 12 00 19 FF FF FF FF FF FF FF ...
```

The parser reads the `FF` bytes as a set "disarmed" mask and publishes `DISARMED` for every partition. The correct register for this firmware is `0x14EC`:

```
TX: F0 EC 14 12 00 02          (0x14EC, KYO32 non-G register)
```

The two registers were already split and hardware-tested in #87; the unification silently reintroduced the bug.

## Fix

Restore the two model-specific constants and route by model:

| Model | Register | Command |
|-------|----------|---------|
| KYO32 non-G | `0x14EC` | `F0 EC 14 12 00 02` |
| KYO32G | `0x1502` | `F0 02 15 12 00 19` |
| KYO8W | `0x1502` | `F0 02 15 12 00 19` |
| KYO4/8/8G | `0x0E68` | `F0 68 0E 09 00 6F` |

**KYO8W deliberately stays on `0x1502`.** Despite its 8-zone hardware it answers with the KYO32-format response and was hardware-confirmed on the `0x1502` register in #109, so it must not fall onto the non-G `0x14EC` address. Only `KYO_32` is special-cased to `0x14EC`; `KYO_32G` and `KYO_8W` keep `0x1502`.

The response layout and length are identical for both registers (`0x12` read length → 26-byte response), so `parse_partition_status_()` is unchanged.

## Regression safety

The only model whose emitted command changes is KYO32 non-G. Command bytes before vs after this change:

| Model | before | after |
|-------|--------|-------|
| KYO4/8/8G | `0x0E68` | `0x0E68` (unchanged) |
| KYO32 non-G | `0x1502` (broken) | `0x14EC` (fixed) |
| KYO32G | `0x1502` | `0x1502` (unchanged) |
| KYO8W | `0x1502` | `0x1502` (unchanged) |

The parser's length/branch selection (`is_kyo8`) is untouched, and there are no other references to the partition-status command or to either register in the codebase.

## Validation

- **KYO32 1.05, live hardware** (by the reporter in #118): after the fix, the night preset correctly showed partitions 1/2/4 `ARMED_AWAY` and 3/5 `DISARMED` through the exit delay, and `Disarm all` returned all five to `DISARMED`.
- **Compile-tested** with ESP-IDF (esp32dev).
- **KYO8W**: no behavioural change — the emitted command is byte-identical to current `master` (`0x1502`), i.e. the register #109 validated.

Docs: `PROTOCOL.md` §5.2 updated — the model/register table previously listed KYO8W under the KYO8 `0x0E68` command; it now correctly sits on `0x1502` with a note about the #118 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
