### PR TITLE
fix(KYO32G): zone config table starts 6 bytes later than the non-G map

### DIFF
--- a/components/bentel_kyo/bentel_kyo.cpp
+++ b/components/bentel_kyo/bentel_kyo.cpp
@@ -1130,16 +1130,24 @@ int BentelKyo::read_register_(uint16_t address, uint8_t length, uint8_t *respons
 
 bool BentelKyo::read_zone_config_() {
   // Zone config: 4 bytes per zone, 16 zones per 64-byte read.
-  // One read per update cycle (block 0 = zones 1-16 at 0x009F, block 1 = 17-32 at
-  // 0x00DF); returns true when done so the loop is never blocked for long.
-  static const uint16_t BASE_ADDRS[] = {0x009F, 0x00DF};
+  // One read per update cycle (block 0 = zones 1-16, block 1 = 17-32); returns true
+  // when done so the loop is never blocked for long.
+  //
+  // KYO32G 2.13 places the table six bytes later than the non-G map documented in
+  // PROTOCOL.md 10.1 — records start at 0x00A5/0x00E5, not 0x009F/0x00DF. Reading the
+  // shifted base (rather than adding a header offset like the KYO8 path below) keeps
+  // all 16 records inside the 64 returned bytes.
+  static const uint16_t BASE_ADDRS_NONG[] = {0x009F, 0x00DF};
+  static const uint16_t BASE_ADDRS_KYO32G[] = {0x00A5, 0x00E5};
+  const uint16_t *base_addrs =
+      (this->alarm_model_ == AlarmModel::KYO_32G) ? BASE_ADDRS_KYO32G : BASE_ADDRS_NONG;
   int num_blocks = (this->max_zones_ > 16) ? 2 : 1;
   int blk = this->config_chunk_index_;
 
   uint8_t rx[255];
-  int count = this->read_register_(BASE_ADDRS[blk], 0x3F, rx, 300);
+  int count = this->read_register_(base_addrs[blk], 0x3F, rx, 300);
   if (count < 6 + 64) {
-    ESP_LOGW(TAG, "Zone config read at 0x%04X failed: got %d bytes", BASE_ADDRS[blk], count);
+    ESP_LOGW(TAG, "Zone config read at 0x%04X failed: got %d bytes", base_addrs[blk], count);
   } else {
     // KYO8 2.04 prefixes the block with a 4-byte header, so zone records start at 0x00A3
     // instead of 0x009F (issue #113 validation: with the shift, every zone lands in the
@@ -1782,12 +1790,24 @@ void BentelKyo::publish_text_sensors_() {
       case TEXT_ZONE_TYPE: {
         if (idx >= (uint8_t) this->max_zones_) continue;
         const char *type_str;
-        switch (this->zone_type_raw_[idx]) {
-          case 0x00: type_str = "Instant"; break;
-          case 0x01: type_str = "Delayed"; break;
-          case 0x02: type_str = "Path"; break;
-          case 0x18: type_str = "Unconfigured"; break;
-          default: type_str = "Unknown"; break;
+        if (this->alarm_model_ == AlarmModel::KYO_32G) {
+          // The panel's own string ROM at 0x34B1 enumerates the eight zone types in this
+          // order, and the low three bits of the record's first byte index it. Confirmed on
+          // KYO32G 2.13 by changing one zone from the keypad and re-reading: Instant kept
+          // 0x?0, Duress produced 0x?4, 24 Hours produced 0x?3 — matching the ROM order.
+          // The remaining bits are not the type (bit 4 tracks the wiring/balance group, as
+          // on KYO8) so they are masked off rather than reported as "Unknown".
+          static const char *const KYO32G_ZONE_TYPES[8] = {
+              "Instant", "Delayed", "Path", "24 Hours", "Duress", "Fire", "Switch", "Arm Only"};
+          type_str = KYO32G_ZONE_TYPES[this->zone_type_raw_[idx] & 0x07];
+        } else {
+          switch (this->zone_type_raw_[idx]) {
+            case 0x00: type_str = "Instant"; break;
+            case 0x01: type_str = "Delayed"; break;
+            case 0x02: type_str = "Path"; break;
+            case 0x18: type_str = "Unconfigured"; break;
+            default: type_str = "Unknown"; break;
+          }
         }
         entry.sensor->publish_state(type_str);
         break;

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1459,7 +1459,7 @@ KyoUnit during upload/download operations. Subject to the same
 | Address | Size | Content | Implemented |
 |---------|------|---------|-------------|
 | `0x0000` | 12B | Firmware version string (ASCII) | Yes |
-| `0x009F` | 128B | Zone configuration (32 × 4 bytes) | Yes |
+| `0x009F` | 128B | Zone configuration (32 × 4 bytes) — `0x00A5` on KYO32G, see 10.29 | Yes |
 | `0x011F` | 80B | Keyfob button config (16 × 5 bytes) | No |
 | `0x016F` | 26B | Timers (entry/exit/siren, 8 partitions) | Yes |
 | `0x019E` | 96B | Zone enrollment/ESN (32 × 3 bytes) | No |
@@ -1505,7 +1505,7 @@ cross-checked against the live entities the component publishes.
 
 | Content | KYO32G address (observed) | Notes |
 |---------|---------------------------|-------|
-| Zone config | `0x009F` (32 × 4) | Same base as non-G; byte 0 = type, byte 2 = area mask (validated against `Zone N Partition` sensors) |
+| Zone config | `0x00A5` / `0x00E5` (32 × 4) | **Six bytes later than the non-G base** — see 10.29. Record layout matches 10.1 |
 | Timers | `0x016F` | All eight areas' entry/exit + siren, areas 5-8 included and correct |
 | Partition names | `0x1750` (8 × 16) | |
 | Zone names | zones 17-32 observed at `0x1AB0`-`0x1BAF`; the 1-16 table precedes it (~`0x19B0`) | |
@@ -1544,6 +1544,58 @@ so programming mode is only observable as a communication loss (the
 communication-status sensor). Real faults still surface through the
 `WARNING_*` binary sensors parsed from the live status poll, so gating these two
 reads loses no genuine fault detection.
+
+### 10.29 KYO32G Zone Configuration Offset (0x00A5-0x0124)
+
+The zone table has the same 4-byte record layout as 10.1, but on KYO32G 2.13 it
+starts **six bytes later** than the non-G base:
+
+```
+Address range: 0x00A5 - 0x0124
+Read as:       F0 A5 00 3F 00 D4 (zones 1-16, 64 bytes)
+               F0 E5 00 3F 00 14 (zones 17-32, 64 bytes)
+```
+
+`0x00A5 + 64 = 0x00E5`, so the two blocks stay contiguous and all 16 records fit
+inside each read. Reading the shifted base is what the component does, rather
+than skipping a header inside the response like the KYO8 path in 9.2 — skipping
+six of the 64 returned data bytes would push the last two records of each block
+past the buffer.
+
+Read at the non-G base, every field lands one field early: `zone N area` is in
+fact zone N-1's type byte, which is how the shift was first noticed (changing one
+zone's type from the keypad moved the *next* zone's reported area).
+
+**Structural confirmation.** 10.1 documents `0x0F` as the last byte of every
+record. With base `0x009F` that byte falls on `0x00A2`/`0x00A6`/`0x00AA`, which
+all read `0x00`; with base `0x00A5` it lands at offset +3 on all 32 zones.
+
+**Zone type** — the low three bits of byte +0 index the eight type strings in the
+panel's string ROM at `0x34B1`, in ROM order:
+
+| Value | Type | | Value | Type |
+|-------|------|-|-------|------|
+| `0` | Instant | | `4` | Duress |
+| `1` | Delayed | | `5` | Fire |
+| `2` | Path | | `6` | Switch |
+| `3` | 24 Hours | | `7` | Arm Only |
+
+Bit 4 carries the wiring/balance group, as on KYO8 (9.2), so the whole byte must
+not be compared against the three-value non-G table — `0x10` is a balanced
+Instant zone, not an unknown type.
+
+> **Verification** (KYO32G 2.13, live hardware): one zone was changed from the
+> keypad and the block re-read. Instant kept `0x?0`, Duress produced `0x?4`,
+> 24 Hours produced `0x?3` — matching ROM order, with no other byte in the block
+> moving. The decoded types for all 14 named zones then matched the panel's own
+> zone list read from the keypad, and the decoded areas matched two independent
+> keypad readings (zone 9 → area 1, zone 15 → area 2).
+
+The non-G base is *not* wrong: 10.1 pins the record layout on a KYO32M using the
+same controlled-change method. The two firmware generations genuinely place the
+table at different addresses, so the component routes by model and only `KYO_32G`
+uses `0x00A5`. Whether KYO8W follows the G or the non-G here is untested — it
+currently uses the non-G base.
 
 ---
 


### PR DESCRIPTION
## Problem

On **KYO32G** the zone-configuration table does not start where the component
reads it. Records begin at `0x00A5`, six bytes after the non-G base `0x009F`.

Read six bytes early, every field lands one field short. `Zone N Partition`
publishes what is actually zone N-1's type byte, and `Zone N Type` publishes a
byte from zone N-2's record. On the reporting panel (KYO32G 2.13, 18 named
zones) that produced `Unknown` on 6 of 14 configured zones and partition
assignments that did not match the panel.

This is how the shift was first noticed: changing one zone's type from the
keypad moved the *next* zone's reported partition.

## Evidence

**1. The table's bounds fit exactly at `0x00A5`.** Section 10.1 documents `0x0F`
as the last byte of every 4-byte record. From a full `memory_scan` dump:

```
0x00A0:  00 00 00 03 00 | 01 00 04 0F | 01 00 04 0F | 10 00 04
0x00B0:  0F | 10 00 04 0F | 10 00 04 0F | 10 00 00 0F | 10 00 40
0x00C0:  0F | 10 00 80 0F | 00 00 01 0F | 11 00 02 0F | 10 00 00
                          ^ zone 9
...
0x0120:  0F | 10 00 04 0F | C0 00 00 01 C0 00 00 01 00 00 00
                          ^ table ends      ^ next structure
```

The `0x0F` marker lands at offset +3 on all 32 records, the table occupies
exactly `0x00A5`-`0x0124` (128 bytes = 32 × 4), and a different structure starts
at `0x0125`. With base `0x009F` the marker would fall on `0x00A2`/`0x00A6`/
`0x00AA`, which all read `0x00`, and the table would end at `0x011E` leaving six
orphan bytes before `0x0125`.

**2. A controlled change moves exactly one byte, at the shifted address.** One
zone was changed from the keypad and the block re-read. Only the byte at
`0x00A5 + 4*(N-1)` moved:

| Keypad setting | Byte value |
|----------------|------------|
| Instant | `0x10` |
| Duress | `0x14` |
| 24 Hours | `0x13` |

The low three bits index the eight zone-type strings in the panel's own string
ROM, in ROM order — visible in the same dump at `0x34B1`, 8-character slots:

```
0x34B0:  20 49 6E 73 74 61 6E 74 20 44 65 6C 61 79 65 64  | Instant Delayed|
0x34C0:  20 20 20 50 61 74 68 20 20 32 34 20 68 6F 75 72  |   Path  24 hour|
0x34D0:  73 20 44 75 72 65 73 73 20 20 20 46 69 72 65 20  |s Duress   Fire |
0x34E0:  20 53 77 69 74 63 68 2E 20 41 72 6D 20 4F 6E 6C  | Switch. Arm Onl|
```

`Instant`, `Delayed`, `Path`, `24 hours`, `Duress`, `Fire`, `Switch.`,
`Arm Only` — values 0 through 7.

**3. Cross-check against the panel.** With the shift applied, the decoded types
for all 14 named zones match the panel's own zone list read from the keypad, and
the decoded areas match two independent keypad readings taken afterwards
(zone 9 → area 1, zone 15 → area 2). Both were predicted from the corrected
parse before being read from the panel.

## Fix

Route the read address by model. The record layout itself (section 10.1) is
unchanged — it was simply anchored six bytes early:

```cpp
static const uint16_t BASE_ADDRS_NONG[]   = {0x009F, 0x00DF};
static const uint16_t BASE_ADDRS_KYO32G[] = {0x00A5, 0x00E5};
```

Shifting the read address rather than skipping a header inside the response
(as the KYO8 path does) is deliberate: the read returns 64 data bytes, so
skipping six of them would push the last two records of each block past the
buffer. `0x00A5 + 64 = 0x00E5`, so the two blocks stay contiguous and all 16
records fit each read.

Zone types are also decoded from the low three bits against the eight-value ROM
table instead of matching the whole byte against three values. Bit 4 carries the
wiring/balance group, as on KYO8, so `0x10` is a balanced Instant zone — under
the old comparison it fell through to `Unknown`.

## Regression safety

Scoped to `KYO_32G`. **Section 10.1 is not being corrected**: it pins the record
layout on a KYO32M using the same controlled-change method used here, so the two
firmware generations genuinely place the table at different addresses.

| Model | Read address | Change |
|-------|--------------|--------|
| KYO4 / KYO8 / KYO8G | `0x009F` / `0x00DF` | none |
| KYO32 non-G | `0x009F` / `0x00DF` | none |
| KYO8W | `0x009F` / `0x00DF` | none |
| KYO32G | `0x00A5` / `0x00E5` | fixed |

- `KYO_32G` is assigned only from the firmware prefix `"KYO32G"`, tested before
  `"KYO32"` (longest match first), so a non-G cannot reach the new branch.
- The response-length fallback can only produce `KYO_32` or `KYO_8`, never
  `KYO_32G`, so an undetected panel keeps the old path.
- `read_zone_config_()` is the only caller of the zone-config base; the other
  `BASE_ADDRS_*` arrays in the file are name tables and are untouched.
- The record parsing inside the block — KYO8 header offset, 8-record cap,
  `[type][enrolled][area][cycles]` — is unchanged.
- The zone-type `switch` for all other models is the original code verbatim,
  only moved into an `else` branch.
- `zone_enrolled_` feeds a debug log line only.

The KYO32G path is validated on live hardware. For every other model this is a
static guarantee that the emitted bytes are identical — I have no KYO8, KYO32
non-G or KYO8W to test on.

Whether KYO8W follows the G or the non-G here is untested; it keeps the non-G
base, i.e. current behaviour.

## Validation

- KYO32G 2.13, live hardware: controlled keypad changes and full `memory_scan`
  dumps as described above.
- Compile-tested with ESP-IDF (esp32dev).

## Docs

New section 10.29 in `PROTOCOL.md` records the shifted base, the read commands,
the structural evidence and the eight-value type enumeration.

It also corrects the 10.28 KYO32G map, which listed the zone config under the
non-G base and cited the component's own `Zone N Partition` sensors as
validation — those sensors were reading the shifted bytes, so the check was
circular. That is why the offset survived the KYO32G mapping work in #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
